### PR TITLE
Use route result observer/subject interfaces from zend-expressive-router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive": "~1.0.0-dev@dev || ^1.0"
+        "zendframework/zend-expressive-router": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -10,7 +10,7 @@ namespace Zend\Expressive\Helper;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\RouteResultObserverInterface;
+use Zend\Expressive\Router\RouteResultObserverInterface;
 
 class UrlHelper implements RouteResultObserverInterface
 {

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -17,6 +17,7 @@ use Zend\Expressive\Helper\Exception\MissingRouterException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Helper\UrlHelperFactory;
 use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Router\RouteResultSubjectInterface;
 
 class UrlHelperFactoryTest extends TestCase
 {
@@ -34,11 +35,11 @@ class UrlHelperFactoryTest extends TestCase
         $this->container->get($name)->willReturn($service);
     }
 
-    public function testRegistersHelperAsApplicationRouteResultObserverWhenApplicationIsPresent()
+    public function testRegistersHelperAsRouteResultObserverWhenApplicationIsPresentInContainer()
     {
         $this->injectContainerService(RouterInterface::class, $this->router->reveal());
 
-        $application = $this->prophesize(Application::class);
+        $application = $this->prophesize(RouteResultSubjectInterface::class);
         $application->attachRouteResultObserver(Argument::type(UrlHelper::class))->shouldBeCalled();
         $this->injectContainerService(Application::class, $application->reveal());
 

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -11,13 +11,12 @@ namespace ZendTest\Expressive\Helper;
 
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Application;
 use Zend\Expressive\Helper\Exception\RuntimeException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\RouteResultObserverInterface;
+use Zend\Expressive\Router\RouteResultObserverInterface;
 
 class UrlHelperTest extends TestCase
 {


### PR DESCRIPTION
This patch updates the code to use the `RouteResultObserverInterface` from zend-expressive-router 1.1.0, vs the one in zend-expressive (as yet unreleased). The change allows the following:

- Fewer dependencies (zend-expressive-router vs zend-expressive + zend-expressive-router + zend-expressive-template)
- No circular dependencies
- Simpler test (mock zend-expressive-router's `RouteResultSubjectInterface` instead of zend-expressive's `Application` class)

This keeps all functionality, making it backwards compatible with 1.0.