### PR TITLE
Implement UrlHelper middleware

### DIFF
--- a/src/Exception/MissingSubjectException.php
+++ b/src/Exception/MissingSubjectException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Helper\Exception;
+
+use DomainException;
+use Interop\Container\Exception\ContainerException;
+
+class MissingSubjectException extends DomainException implements
+    ContainerException,
+    ExceptionInterface
+{
+}

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -31,13 +31,6 @@ class UrlHelperFactory
             ));
         }
 
-        $helper = new UrlHelper($container->get(RouterInterface::class));
-
-        if ($container->has(Application::class)) {
-            $application = $container->get(Application::class);
-            $application->attachRouteResultObserver($helper);
-        }
-
-        return $helper;
+        return new UrlHelper($container->get(RouterInterface::class));
     }
 }

--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Helper;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Router\RouteResultSubjectInterface;
+
+/**
+ * Pipeline middleware for attaching a UrlHelper to a
+ * RouteResultSubjectInterface instance.
+ */
+class UrlHelperMiddleware
+{
+    /**
+     * @var UrlHelper
+     */
+    private $helper;
+
+    /**
+     * @var RouteResultSubjectInterface
+     */
+    private $subject;
+
+    /**
+     * @param UrlHelper $helper
+     * @param RouteResultSubjectInterface $subject
+     */
+    public function __construct(UrlHelper $helper, RouteResultSubjectInterface $subject)
+    {
+        $this->helper = $helper;
+        $this->subject = $subject;
+    }
+
+    /**
+     * Attach the UrlHelper instance as an observer to the RouteResultSubjectInterface
+     *
+     * Attaches the helper, and then dispatches the next middleware.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $next
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $this->subject->attachRouteResultObserver($this->helper);
+        return $next($request, $response);
+    }
+}

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Helper;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\Router\RouteResultSubjectInterface;
+
+class UrlHelperMiddlewareFactory
+{
+    /**
+     * Create and return a UrlHelperMiddleware instance.
+     *
+     * @param ContainerInterface $container
+     * @return UrlHelperMiddleware
+     * @throws Exception\MissingHelperException if the UrlHelper service is
+     *     missing
+     * @throws Exception\MissingSubjectException if the
+     *     RouteResultSubjectInterface service is missing
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        if (! $container->has(UrlHelper::class)) {
+            throw new Exception\MissingHelperException(sprintf(
+                '%s requires a %s service at instantiation; none found',
+                UrlHelperMiddleware::class,
+                UrlHelper::class
+            ));
+        }
+
+        $subjectService = $this->getSubjectService($container);
+
+        return new UrlHelperMiddleware(
+            $container->get(UrlHelper::class),
+            $container->get($subjectService)
+        );
+    }
+
+    /**
+     * Determine the name of the service returning the RouteResultSubjectInterface instance.
+     *
+     * Checks against:
+     *
+     * - RouteResultSubjectInterface
+     * - Application
+     *
+     * returning the first that is found in the container.
+     *
+     * If neither is found, raises an exception.
+     *
+     * @param ContainerInterface $container
+     * @return string
+     * @throws Exception\MissingSubjectException
+     */
+    private function getSubjectService(ContainerInterface $container)
+    {
+        if ($container->has(RouteResultSubjectInterface::class)) {
+            return RouteResultSubjectInterface::class;
+        }
+
+        if ($container->has(Application::class)) {
+            return Application::class;
+        }
+
+        throw new Exception\MissingSubjectException(sprintf(
+            '%s requires a %s service at instantiation; none found',
+            UrlHelperMiddleware::class,
+            UrlHelper::class
+        ));
+    }
+}

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -11,13 +11,10 @@ namespace ZendTest\Expressive\Helper;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
-use Prophecy\Argument;
-use Zend\Expressive\Application;
 use Zend\Expressive\Helper\Exception\MissingRouterException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Helper\UrlHelperFactory;
 use Zend\Expressive\Router\RouterInterface;
-use Zend\Expressive\Router\RouteResultSubjectInterface;
 
 class UrlHelperFactoryTest extends TestCase
 {
@@ -35,27 +32,16 @@ class UrlHelperFactoryTest extends TestCase
         $this->container->get($name)->willReturn($service);
     }
 
-    public function testRegistersHelperAsRouteResultObserverWhenApplicationIsPresentInContainer()
+    public function testFactoryReturnsHelperWithRouterInjected()
     {
         $this->injectContainerService(RouterInterface::class, $this->router->reveal());
 
-        $application = $this->prophesize(RouteResultSubjectInterface::class);
-        $application->attachRouteResultObserver(Argument::type(UrlHelper::class))->shouldBeCalled();
-        $this->injectContainerService(Application::class, $application->reveal());
-
         $helper = $this->factory->__invoke($this->container->reveal());
         $this->assertInstanceOf(UrlHelper::class, $helper);
+        $this->assertAttributeSame($this->router->reveal(), 'router', $helper);
     }
 
-    public function testReturnsUrlHelperEvenWhenApplicationIsNotPresentInContainer()
-    {
-        $this->injectContainerService(RouterInterface::class, $this->router->reveal());
-        $this->container->has(Application::class)->willReturn(false);
-        $helper = $this->factory->__invoke($this->container->reveal());
-        $this->assertInstanceOf(UrlHelper::class, $helper);
-    }
-
-    public function testRaisesExceptionWhenRouterIsNotPresentInContainer()
+    public function testFactoryRaisesExceptionWhenRouterIsNotPresentInContainer()
     {
         $this->setExpectedException(MissingRouterException::class);
         $this->factory->__invoke($this->container->reveal());

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Helper;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Zend\Expressive\Application;
+use Zend\Expressive\Helper\Exception\MissingHelperException;
+use Zend\Expressive\Helper\Exception\MissingSubjectException;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Helper\UrlHelperMiddleware;
+use Zend\Expressive\Helper\UrlHelperMiddlewareFactory;
+use Zend\Expressive\Router\RouteResultSubjectInterface;
+
+class UrlHelperMiddlewareFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function injectContainer($name, $service)
+    {
+        $service = $service instanceof ObjectProphecy ? $service->reveal() : $service;
+        $this->container->has($name)->willReturn(true);
+        $this->container->get($name)->willReturn($service);
+    }
+
+    public function testFactoryCreatesAndReturnsMiddlewareWhenHelperAndSubjectArePresentInContainer()
+    {
+        $helper = $this->prophesize(UrlHelper::class)->reveal();
+        $subject = $this->prophesize(RouteResultSubjectInterface::class)->reveal();
+        $this->injectContainer(UrlHelper::class, $helper);
+        $this->injectContainer(RouteResultSubjectInterface::class, $subject);
+
+        $factory = new UrlHelperMiddlewareFactory();
+        $middleware =$factory($this->container->reveal());
+        $this->assertInstanceOf(UrlHelperMiddleware::class, $middleware);
+        $this->assertAttributeSame($helper, 'helper', $middleware);
+        $this->assertAttributeSame($subject, 'subject', $middleware);
+    }
+
+    public function testFactoryCreatesAndReturnsMiddlewareWhenHelperAndApplicationArePresentInContainer()
+    {
+        $helper = $this->prophesize(UrlHelper::class)->reveal();
+        $subject = $this->prophesize(RouteResultSubjectInterface::class)->reveal();
+        $this->injectContainer(UrlHelper::class, $helper);
+        $this->container->has(RouteResultSubjectInterface::class)->willReturn(false);
+        $this->injectContainer(Application::class, $subject);
+
+        $factory = new UrlHelperMiddlewareFactory();
+        $middleware =$factory($this->container->reveal());
+        $this->assertInstanceOf(UrlHelperMiddleware::class, $middleware);
+        $this->assertAttributeSame($helper, 'helper', $middleware);
+        $this->assertAttributeSame($subject, 'subject', $middleware);
+    }
+
+    public function testFactoryRaisesExceptionWhenContainerDoesNotContainHelper()
+    {
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $this->injectContainer(
+            RouteResultSubjectInterface::class,
+            $this->prophesize(RouteResultSubjectInterface::class)
+        );
+        $factory = new UrlHelperMiddlewareFactory();
+        $this->setExpectedException(MissingHelperException::class);
+        $middleware =$factory($this->container->reveal());
+    }
+
+    public function testFactoryRaisesExceptionWhenContainerDoesNotContainSubject()
+    {
+        $this->injectContainer(UrlHelper::class, $this->prophesize(UrlHelper::class));
+        $this->container->has(RouteResultSubjectInterface::class)->willReturn(false);
+        $this->container->has(Application::class)->willReturn(false);
+        $factory = new UrlHelperMiddlewareFactory();
+        $this->setExpectedException(MissingSubjectException::class);
+        $middleware =$factory($this->container->reveal());
+    }
+}

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Helper\UrlHelperMiddleware;
+use Zend\Expressive\Router\RouteResultSubjectInterface;
+
+class UrlHelperMiddlewareTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->application = $this->prophesize(RouteResultSubjectInterface::class);
+        $this->helper = $this->prophesize(UrlHelper::class);
+    }
+
+    public function createMiddleware()
+    {
+        return new UrlHelperMiddleware(
+            $this->helper->reveal(),
+            $this->application->reveal()
+        );
+    }
+
+    public function testInvocationRegistersHelperAsObserverOnRouteResultSubject()
+    {
+        $this->application
+            ->attachRouteResultObserver($this->helper->reveal())
+            ->shouldBeCalled();
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $response = $this->prophesize(ResponseInterface::class);
+        $next = function ($req, $res) {
+            return 'COMPLETE';
+        };
+        $middleware = $this->createMiddleware();
+        $this->assertEquals('COMPLETE', $middleware(
+            $request->reveal(),
+            $response->reveal(),
+            $next
+        ));
+    }
+}


### PR DESCRIPTION
As noted in a [comment on a zend-expressive issue](https://github.com/zendframework/zend-expressive/issues/186#issuecomment-162941737), the current approach to registering the `UrlHelper` is not feasible, due to the following issues:

- In cases where the `UrlHelper` is pulled during creation of the `TemplateRendererInterface` instance, and a `TemplatedErrorHandler` (or derivative, such as the whoops error handler) is also used, a circular dependency occurs. This is due to the `UrlHelperFactory` also pulling the `Application` service (as the `TemplatedErrorHandler` instance is pulled inside the `ApplicationFactory`).
- In cases where the `UrlHelper` creation is delayed until first use (e.g., in zend-expressive-zendviewrenderer's `url` helper factory), the helper is created *after* route result observers are updated, which means the helper never receives the route result.

This patch does the following:

- Creates `UrlHelperMiddleware`, which composes a `UrlHelper` and a `RouteResultSubjectInterface` instance; when invoked, it attaches the helper to the subject as an observer.
- Creates `UrlHelperMiddlewareFactory`, which creates a `UrlHelperMiddleware` instance, using the `UrlHelper` service, and either the `RouteResultSubjectInterface` or `Application` service instance.
- Modifies the `UrlHelperFactory` to no longer pull the `Application` instance and attach the helper to it.

The plan is to update zend-expressive-skeleton to auto-register the `UrlHelperMiddleware` as pipeline middleware, just as we have done with the `ServerUrlMiddleware`.