### PR TITLE
support alternate signature when using current route result

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -51,6 +51,11 @@ class UrlHelper
      */
     public function __invoke($route = null, array $params = [])
     {
+        if (is_array($route)) {
+            $params = $route;
+            $route  = null;
+        }
+
         $result = $this->getRouteResult();
         if ($route === null && $result === null) {
             throw new Exception\RuntimeException(


### PR DESCRIPTION
Allows skipping null argument when generating url from current route with different substitutions.

@weierophinney 
If you believe it to be not useful at all, pls close it at once, otherwise i will go on and add some tests.
kind regards