### PR TITLE
Base path now prepended when no route specified

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -157,7 +157,12 @@ class UrlHelper
 
         $name   = $result->getMatchedRouteName();
         $params = array_merge($result->getMatchedParams(), $params);
-        return $this->router->generateUri($name, $params);
+
+        if ($this->basePath === '/') {
+            return $this->router->generateUri($name, $params);
+        }
+
+        return $this->basePath . $this->router->generateUri($name, $params);
     }
 
     /**

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -165,4 +165,19 @@ class UrlHelperTest extends TestCase
         $helper->setBasePath('/prefix');
         $this->assertEquals('/prefix/foo/baz', $helper('foo', ['bar' => 'baz']));
     }
+
+    public function testBasePathIsPrependedWhenNoRouteProvided()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRouteName()->willReturn('foo');
+        $result->getMatchedParams()->willReturn([]);
+        $result = $result->reveal();
+
+        $this->router->generateUri('foo', [])->willReturn('/foo');
+        $helper = $this->createHelper();
+        $helper->setRouteResult($result);
+        $helper->setBasePath('/prefix');
+        $this->assertEquals('/prefix/foo', $helper());
+    }
 }


### PR DESCRIPTION
This fixes an issue where the `basePath` is not prepended to the current route when no route is passed to the helper:

```
// current route match is '/bar'
$helper->setBasePath('foo');
echo $helper();
// outputs '/foo/bar'
```
