### PR TITLE
prepend basePath when autogenerating from route result

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -59,19 +59,17 @@ class UrlHelper
         }
 
         if ($route === null) {
-            return $this->generateUriFromResult($params, $result);
-        }
-
-        if ($this->result) {
-            $params = $this->mergeParams($route, $result, $params);
+            $url = $this->generateUriFromResult($params, $result);
+        } else {
+            if ($result) {
+                $params = $this->mergeParams($route, $result, $params);
+            }
+            $url = $this->router->generateUri($route, $params);
         }
 
         $basePath = $this->getBasePath();
-        if ($basePath === '/') {
-            return $this->router->generateUri($route, $params);
-        }
 
-        return $basePath . $this->router->generateUri($route, $params);
+        return ($basePath === '/') ? $url : $basePath . $url;
     }
 
     /**

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -165,4 +165,24 @@ class UrlHelperTest extends TestCase
         $helper->setBasePath('/prefix');
         $this->assertEquals('/prefix/foo/baz', $helper('foo', ['bar' => 'baz']));
     }
+
+    public function testBasePathIsPrependedToGeneratedPathWhenUsingRouteResult()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRouteName()->willReturn('foo');
+        $result->getMatchedParams()->willReturn(['bar' => 'baz']);
+
+        $this->router->generateUri('foo', ['bar' => 'baz'])->willReturn('/foo/baz');
+
+        $helper = $this->createHelper();
+        $helper->setBasePath('/prefix');
+        $helper->setRouteResult($result->reveal());
+
+        // test with explicit params
+        $this->assertEquals('/prefix/foo/baz', $helper(null, ['bar' => 'baz']));
+
+        // test with implicit route result params
+        $this->assertEquals('/prefix/foo/baz', $helper());
+    }
 }


### PR DESCRIPTION
I believe that invoking helper should end in consistent results with generated urls containing - if set - the basePath prefix.
Should we also avoid getter (getRouteResult, getBasePath) calls and use $this->result and $this->basePath directly? 
(code contained mixed getter and property call for result)
I don't see any reason why those getter should be eventually overridden in a child class to send something different from the internal properties themselves.

kind regards