### PR TITLE
Respond with 400 on bad JSON input

### DIFF
--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -83,17 +83,10 @@ class BodyParamsMiddleware
             }
 
             // Matched! Parse and pass on to the next
-            try {
-                return $next(
-                    $strategy->parse($request),
-                    $response
-                );
-            } catch (MalformedRequestBodyException $exception) {
-                return $next(
-                    $request,
-                    $response->withStatus($exception->getCode(), $exception->getMessage())
-                );
-            }
+            return $next(
+                $strategy->parse($request),
+                $response
+            );
         }
 
         // No match; continue

--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -9,6 +9,7 @@ namespace Zend\Expressive\Helper\BodyParams;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
 
 class BodyParamsMiddleware
 {
@@ -82,10 +83,17 @@ class BodyParamsMiddleware
             }
 
             // Matched! Parse and pass on to the next
-            return $next(
-                $strategy->parse($request),
-                $response
-            );
+            try {
+                return $next(
+                    $strategy->parse($request),
+                    $response
+                );
+            } catch (MalformedRequestBodyException $exception) {
+                return $next(
+                    $request,
+                    $response->withStatus($exception->getCode(), $exception->getMessage())
+                );
+            }
         }
 
         // No match; continue

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -31,10 +31,7 @@ class JsonStrategy implements StrategyInterface
         $parsedBody = json_decode($rawBody, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new MalformedRequestBodyException(
-                'Error when parsing JSON request body: ' . json_last_error_msg(),
-                400
-            );
+            throw new MalformedRequestBodyException('Error when parsing JSON request body: ' . json_last_error_msg());
         }
 
         return $request

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -8,6 +8,7 @@
 namespace Zend\Expressive\Helper\BodyParams;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
 
 class JsonStrategy implements StrategyInterface
 {
@@ -27,8 +28,17 @@ class JsonStrategy implements StrategyInterface
     public function parse(ServerRequestInterface $request)
     {
         $rawBody = (string) $request->getBody();
+        $parsedBody = json_decode($rawBody, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new MalformedRequestBodyException(
+                'Error when parsing JSON request body: ' . json_last_error_msg(),
+                400
+            );
+        }
+
         return $request
             ->withAttribute('rawBody', $rawBody)
-            ->withParsedBody(json_decode($rawBody, true));
+            ->withParsedBody($parsedBody);
     }
 }

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Helper\Exception;
+
+use InvalidArgumentException;
+
+class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -13,4 +13,8 @@ use InvalidArgumentException;
 
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct($message, 400, $previous);
+    }
 }

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -136,7 +136,7 @@ class UrlHelper
      *
      * @return string
      */
-    protected function getBasePath()
+    public function getBasePath()
     {
         return $this->basePath;
     }

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -11,6 +11,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Helper\BodyParams\JsonStrategy;
+use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
 
 class JsonStrategyTest extends TestCase
 {
@@ -72,5 +73,21 @@ class JsonStrategyTest extends TestCase
         });
 
         $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
+    }
+
+    public function testThrowsExceptionOnMalformedJsonInRequestBody()
+    {
+        $this->setExpectedException(
+            MalformedRequestBodyException::class,
+            'Error when parsing JSON request body: Syntax error',
+            400
+        );
+        $body = '{foobar}';
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->__toString()->willReturn($body);
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getBody()->willReturn($stream->reveal());
+
+        $this->strategy->parse($request->reveal());
     }
 }


### PR DESCRIPTION
@weierophinney thoughts on this to address #12 ?

The `BodyParamsMiddleware` isn't really supposed to be aware of the internals of the `Strategy`, so it wouldn't make sense to check the resulting null parsed body to guess as to what happened. The strategy doesn't have access to the `Response` either, so we can't do anything with it there.

Best approach I could think of was an exception specifically for malformed request bodies which the `Strategy` classes could use to communicate with the middleware that invoked them.

Finally, since a simple `Bad Request` isn't terribly useful to describe what went wrong, I opted to use the output from `json_last_error_msg()`. I think this should be fine because the [json_last_error_msg](https://secure.php.net/manual/en/function.json-last-error.php#refsect1-function.json-last-error-returnvalues) texts don't seem to leak anything sensitive... and the person making the request obviously knows what the request looks like already.