### PR TITLE
fix test suite with jsonc extension

### DIFF
--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -79,7 +79,7 @@ class JsonStrategyTest extends TestCase
     {
         $this->setExpectedException(
             MalformedRequestBodyException::class,
-            'Error when parsing JSON request body: Syntax error',
+            'Error when parsing JSON request body: ',
             400
         );
         $body = '{foobar}';


### PR DESCRIPTION
Most downstream distribution use (with PHP 5) jsonc extension (instead of non-free json)

Only the error message is different, but the exception is properly raised.
This trivial patch allow the test suite to pass with both json and jsonc extensions.