### PR TITLE
Support generating default route w/o parameters

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -42,6 +42,7 @@ class UrlHelper
      *
      * @param string $routeName
      * @param array $params
+     * @param bool $reuseResultParams
      * @return string
      * @throws Exception\RuntimeException if no route provided, and no result match
      *     present.
@@ -49,7 +50,7 @@ class UrlHelper
      *     routing failure.
      * @throws RouterException if router cannot generate URI for given route.
      */
-    public function __invoke($routeName = null, array $params = [])
+    public function __invoke($routeName = null, array $params = [], $reuseResultParams = true)
     {
         $result = $this->getRouteResult();
         if ($routeName === null && $result === null) {
@@ -67,7 +68,7 @@ class UrlHelper
             return $basePath . $this->generateUriFromResult($params, $result);
         }
 
-        if ($result) {
+        if ($result && $reuseResultParams) {
             $params = $this->mergeParams($routeName, $result, $params);
         }
 

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -136,6 +136,21 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource', ['id' => 2]));
     }
 
+    public function testWillNotReuseRouteResultParamsIfReuseResultParamsFlagIsFalseWhenGeneratingUri()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRouteName()->willReturn('resource');
+        $result->getMatchedParams()->willReturn(['id' => 1]);
+
+        $this->router->generateUri('resource', [])->willReturn('URL');
+
+        $helper = $this->createHelper();
+        $helper->setRouteResult($result->reveal());
+
+        $this->assertEquals('URL', $helper('resource', [], false));
+    }
+
     public function testCanInjectRouteResult()
     {
         $result = $this->prophesize(RouteResult::class);


### PR DESCRIPTION
Given a matched route with name `album.index` and path `/album[/page/{page:\d+}]`, invoking the `UrlHelper` with the route name `album.index` and no additional parameters while on page 5 would return `/album/page/5`, since it automatically merges existing params from the `RouteResult`. This behavior would make it impossible to use the `UrlHelper` to generate the base `/album` URL while on any page.

Invoking the helper with the new third argument `$reuseResultParams` set to `false` will now cause the helper to only take the params provided in the 2nd `$params` argument into consideration, which will produce the base `/album` URL in the above example.

BC Breaks:
  - None if `UrlHelper` is being consumed directly.
  - Method signature change if `UrlHelper` has been extended.

This addresses #10 , but due to the BC break I've set the milestone to `3.0.0`. If this is 👍'ed, I'll likely gather any other potential BC breaking contributions and release them all at once as `3.0.0` with the intention of bringing the helpers repo down to 0 open issues and 0 PRs.