### PR TITLE
Achieve 100% test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require-dev": {
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-diactoros": "^1.2"
+        "zendframework/zend-diactoros": "^1.2",
+        "mockery/mockery": "^0.9.5"
     },
     "autoload": {
       "psr-4": {

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -155,4 +155,17 @@ class ServerUrlHelperTest extends TestCase
         $helper->setUri($uri);
         $this->assertEquals($expected, $helper($path));
     }
+
+    public function testGenerateProxiesToInvokeMethod()
+    {
+        $path = '/foo';
+
+        $helper = \Mockery::mock(ServerUrlHelper::class)->shouldDeferMissing();
+        $helper->shouldReceive('__invoke')
+            ->once()
+            ->with($path)
+            ->andReturn('it worked');
+
+        $this->assertSame('it worked', $helper->generate($path));
+    }
 }


### PR DESCRIPTION
This PR brings the project to 100% unit test coverage.

I don't see any kind of minimum test coverage percentage requirement in this repo or in any of the other Expressive project repos, but now that 100% coverage has been reached, I don't see any reason why it couldn't be retained. Generally, well-written code is easy to test, and code being difficult to test is a smell, IMO, so I'd like to require 100% for future `zend-expressive-helpers` contributions (and require no reduction in existing coverage for other Expressive repos as I get to them).

Thoughts, @weierophinney ? If 👍, I'll add a check to `.travis.yml` for this and merge.