### PR TITLE
Removes unused class use in BodyParamsMiddleware

### DIFF
--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -9,7 +9,6 @@ namespace Zend\Expressive\Helper\BodyParams;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
 
 class BodyParamsMiddleware
 {


### PR DESCRIPTION
MalformedRequestBodyException usage has been moved to JsonStrategy.