### PR TITLE
Add query parameters and fragment support

### DIFF
--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -9,13 +9,12 @@
 
 namespace ZendTest\Expressive\Helper;
 
-use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Helper\Exception\RuntimeException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class UrlHelperTest extends TestCase
 {
@@ -259,27 +258,30 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('foo', [], [], null, ['router' => ['bar' => 'baz']]));
     }
 
-    public function testQueryParametersAreAppended()
+    public function queryParametersAndFragmentProvider()
     {
-        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
-        $helper = $this->createHelper();
-
-        $this->assertEquals('/foo/baz?qux=quux', $helper('foo', ['bar' => 'baz'], ['qux' => 'quux']));
+        // @codingStandardsIgnoreStart
+        return [
+            'none'           => [[], null, ''],
+            'empty-fragment' => [[], '', ''],
+            'query'          => [['qux' => 'quux'], null, '?qux=quux'],
+            'fragment'       => [[], 'corge', '#corge'],
+            'query+fragment' => [['qux' => 'quux'], 'corge', '?qux=quux#corge'],
+        ];
+        // @codingStandardsIgnoreEnd
     }
 
-    public function testFragmentIsAppended()
+    /**
+     * @dataProvider queryParametersAndFragmentProvider
+     */
+    public function testQueryParametersAndFragment(array $queryParams, $fragmentIdentifier, $expected)
     {
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
 
-        $this->assertEquals('/foo/baz#corge', $helper('foo', ['bar' => 'baz'], [], 'corge'));
-    }
-
-    public function testQueryParametersAndFragmentAreAppended()
-    {
-        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
-        $helper = $this->createHelper();
-
-        $this->assertEquals('/foo/baz?qux=quux#corge', $helper('foo', ['bar' => 'baz'], ['qux' => 'quux'], 'corge'));
+        $this->assertEquals(
+            '/foo/baz' . $expected,
+            $helper('foo', ['bar' => 'baz'], $queryParams, $fragmentIdentifier)
+        );
     }
 }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -148,7 +148,7 @@ class UrlHelperTest extends TestCase
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
 
-        $this->assertEquals('URL', $helper('resource', [], ['reuse_result_params' => false]));
+        $this->assertEquals('URL', $helper('resource', [], [], null, ['reuse_result_params' => false]));
     }
 
     public function testCanInjectRouteResult()
@@ -256,7 +256,7 @@ class UrlHelperTest extends TestCase
     {
         $this->router->generateUri('foo', [], ['bar' => 'baz'])->willReturn('URL');
         $helper = $this->createHelper();
-        $this->assertEquals('URL', $helper('foo', [], ['router' => ['bar' => 'baz']]));
+        $this->assertEquals('URL', $helper('foo', [], [], null, ['router' => ['bar' => 'baz']]));
     }
 
     public function testQueryParametersAreAppended()
@@ -264,16 +264,7 @@ class UrlHelperTest extends TestCase
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
 
-        $parameters = [
-            'route' => [
-                'bar' => 'baz'
-            ],
-            'query' => [
-                'qux' => 'quux'
-            ]
-        ];
-
-        $this->assertEquals('/foo/baz?qux=quux', $helper('foo', $parameters));
+        $this->assertEquals('/foo/baz?qux=quux', $helper('foo', ['bar' => 'baz'], ['qux' => 'quux']));
     }
 
     public function testFragmentIsAppended()
@@ -281,14 +272,7 @@ class UrlHelperTest extends TestCase
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
 
-        $parameters = [
-            'route' => [
-                'bar' => 'baz'
-            ],
-            'fragment' => 'corge'
-        ];
-
-        $this->assertEquals('/foo/baz#corge', $helper('foo', $parameters));
+        $this->assertEquals('/foo/baz#corge', $helper('foo', ['bar' => 'baz'], [], 'corge'));
     }
 
     public function testQueryParametersAndFragmentAreAppended()
@@ -296,16 +280,6 @@ class UrlHelperTest extends TestCase
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
 
-        $parameters = [
-            'route' => [
-                'bar' => 'baz'
-            ],
-            'query' => [
-                'qux' => 'quux'
-            ],
-            'fragment' => 'corge'
-        ];
-
-        $this->assertEquals('/foo/baz?qux=quux#corge', $helper('foo', $parameters));
+        $this->assertEquals('/foo/baz?qux=quux#corge', $helper('foo', ['bar' => 'baz'], ['qux' => 'quux'], 'corge'));
     }
 }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -148,7 +148,7 @@ class UrlHelperTest extends TestCase
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
 
-        $this->assertEquals('URL', $helper('resource', [], false));
+        $this->assertEquals('URL', $helper('resource', [], ['reuse_result_params' => false]));
     }
 
     public function testCanInjectRouteResult()
@@ -256,6 +256,56 @@ class UrlHelperTest extends TestCase
     {
         $this->router->generateUri('foo', [], ['bar' => 'baz'])->willReturn('URL');
         $helper = $this->createHelper();
-        $this->assertEquals('URL', $helper('foo', [], true, ['bar' => 'baz']));
+        $this->assertEquals('URL', $helper('foo', [], ['router' => ['bar' => 'baz']]));
+    }
+
+    public function testQueryParametersAreAppended()
+    {
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
+        $helper = $this->createHelper();
+
+        $parameters = [
+            'route' => [
+                'bar' => 'baz'
+            ],
+            'query' => [
+                'qux' => 'quux'
+            ]
+        ];
+
+        $this->assertEquals('/foo/baz?qux=quux', $helper('foo', $parameters));
+    }
+
+    public function testFragmentIsAppended()
+    {
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
+        $helper = $this->createHelper();
+
+        $parameters = [
+            'route' => [
+                'bar' => 'baz'
+            ],
+            'fragment' => 'corge'
+        ];
+
+        $this->assertEquals('/foo/baz#corge', $helper('foo', $parameters));
+    }
+
+    public function testQueryParametersAndFragmentAreAppended()
+    {
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
+        $helper = $this->createHelper();
+
+        $parameters = [
+            'route' => [
+                'bar' => 'baz'
+            ],
+            'query' => [
+                'qux' => 'quux'
+            ],
+            'fragment' => 'corge'
+        ];
+
+        $this->assertEquals('/foo/baz?qux=quux#corge', $helper('foo', $parameters));
     }
 }


### PR DESCRIPTION
This PR adds support for query parameters and fragments as discussed in zendframework/zend-expressive#325.

The invoke function has now this signature:

```php
public function __invoke($routeName = null, $params = [], $options = []);
```

- **$routeName**
    Behaves exactly as it does now
- **$params**
    Can have the following keys: `route`, `query`, `fragment`.
    - `route` is an array containing the route parameters
    - `query` appends query params
    - `fragment` appends a fragment identifier, respectively
- **$options**
    Can have the following keys: router, reuse_result_params.
    - `router` must be an array containing the router options
    - `reuse_result_params` is a boolean to indicate if the current RouteResult parameters will be used, defaults to true.