### PR TITLE
Don't throw exception on empty JSON body

### DIFF
--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -30,7 +30,7 @@ class JsonStrategy implements StrategyInterface
         $rawBody = (string) $request->getBody();
         $parsedBody = json_decode($rawBody, true);
 
-        if (!empty($rawBody) && json_last_error() !== JSON_ERROR_NONE) {
+        if (! empty($rawBody) && json_last_error() !== JSON_ERROR_NONE) {
             throw new MalformedRequestBodyException('Error when parsing JSON request body: ' . json_last_error_msg());
         }
 

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -30,7 +30,7 @@ class JsonStrategy implements StrategyInterface
         $rawBody = (string) $request->getBody();
         $parsedBody = json_decode($rawBody, true);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        if (!empty($rawBody) && json_last_error() !== JSON_ERROR_NONE) {
             throw new MalformedRequestBodyException('Error when parsing JSON request body: ' . json_last_error_msg());
         }
 

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -90,4 +90,21 @@ class JsonStrategyTest extends TestCase
 
         $this->strategy->parse($request->reveal());
     }
+
+    public function testEmptyRequestBodyYieldsNullParsedBodyWithNoExceptionThrown()
+    {
+        $body = '';
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->__toString()->willReturn($body);
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getBody()->willReturn($stream->reveal());
+        $request->withAttribute('rawBody', $body)->will(function () use ($request) {
+            return $request->reveal();
+        });
+        $request->withParsedBody(null)->will(function () use ($request) {
+            return $request->reveal();
+        });
+
+        $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
+    }
 }


### PR DESCRIPTION
`2.0.3` introduced an issue where a request along the lines of `PATCH /foo` with
`Content-Type: application/json` but no actual request body (since there may not
actually be any information to provide) would result in an exception. The
previous behavior was that the request would be allowed and the Parsed Body
would be NULL.

@weierophinney this pertains to what we discussed briefly via e-mail a while back.

Other possible alternatives would be to either require the user to use `text/plain` (or something else) as the content type when not needing to provide a request body in order for the `JsonStrategy` to not be executed (which would be a bit of a hassle if 100% of all other requests were `application/json`) *_OR_* to require the user to provide a valid empty JSON structure (`{}`, `'""'`, etc...), which would also be a bit of a bother, since the intent seems clear ("do this thing which doesn't require any further information to be provided as input from me").

I opted for `NULL` as the resulting parsed body rather than an empty array or empty object type since `NULL` was the end result prior to `2.0.3`, and I figure that's one fewer vector for BC breakage.