### PR TITLE
3.0.0 readiness check

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,23 @@ matrix:
     - php: hhvm
 
 before_install:
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls:^1.0 ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update michaelmoussa/php-coverage-checker:^1.1.0 ; fi
 
 install:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update michaelmoussa/php-coverage-checker:^1.1.0 ; fi
-  - travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source
+  - travis_retry composer install --no-interaction
   - composer info -i
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage && vendor/bin/php-coverage-checker clover.xml 100 ; else composer test ; fi
+  - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer check-coverage ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs ; fi
+
+after_script:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer coveralls ; fi
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
     - php: 5.6
       env:
-        - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7
+      env:
+        - CS_CHECK=true
+    - php: 7.1
     - php: hhvm
   allow_failures:
     - php: hhvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.0.0 - 2016-12-??
+## 3.0.0 - 2016-01-11
 
 ### Added
 
@@ -10,8 +10,16 @@ All notable changes to this project will be documented in this file, in reverse 
   default route w/o parameters
 - [#9](https://github.com/zendframework/zend-expressive-helpers/pull/9) UrlHelper passes `$routerOptions` to underlying
   router, if provided.
+  - **BREAKING CHANGE:** This change adds an _optional_ `$options` parameter to the `UrlHelper::__invoke(...)` and
+    `UrlHelper::generate(...)` methods. Users who have extended this class **MUST** update the method signatures
+    accordingly to avoid a PHP Fatal Error. If you have not extended this class, no further action is required for
+    compatibility.
 - [#27](https://github.com/zendframework/zend-expressive-helpers/pull/27) adds query params and fragment identifier
    support to `UrlHelper`
+  - **BREAKING CHANGE:** This change adds _optional_ `$routeParams`, `$queryParams`, and `$fragmentIdentifier` parameters
+    to the `UrlHelper::__invoke(...)` and `UrlHelper::generate(...)` methods, in addition to the aforementioned
+    `$options` parameter. Users who have extended this class **MUST** update the method signatures accordingly to
+    avoid a PHP Fatal Error. If you have not extended this class, no further action is required for compatibility.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.0.0 - TBD
+## 3.0.0 - 2016-12-??
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.2.1 - TBD
+## 3.0.0 - TBD
 
 ### Added
 
-- Nothing.
+- [#23](https://github.com/zendframework/zend-expressive-helpers/pull/23) adds support to UrlHelper for generating
+  default route w/o parameters
+- [#9](https://github.com/zendframework/zend-expressive-helpers/pull/9) UrlHelper passes `$routerOptions` to underlying
+  router, if provided.
+- [#27](https://github.com/zendframework/zend-expressive-helpers/pull/27) adds query params and fragment identifier
+   support to `UrlHelper`
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Helper classes for Expressive
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-expressive-helpers.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-expressive-helpers)
+[![Coverage Status](https://coveralls.io/repos/github/zendframework/zend-expressive-helpers/badge.svg?branch=master)](https://coveralls.io/github/zendframework/zend-expressive-helpers?branch=master)
 
 Helper classes for [Expressive](https://github.com/zendframework/zend-expressive).
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.1"
+        "zendframework/zend-expressive-router": "^2.0.0-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,8 @@
             "@cs",
             "@test"
         ],
+        "check-coverage": "vendor/bin/php-coverage-checker clover.xml 100",
+        "coveralls": "coveralls -v",
         "cs": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,15 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev",
-            "dev-develop": "2.3-dev",
-            "dev-dev-3.0.0": "3.0.0-dev"
+            "dev-master": "3.0-dev",
+            "dev-develop": "3.1-dev"
         }
     },
     "require": {
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^2.0.0-dev"
+        "zendframework/zend-expressive-router": "^2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -9,11 +9,18 @@ namespace Zend\Expressive\Helper;
 
 use InvalidArgumentException;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class UrlHelper
 {
+    /**
+     * Regular expression used to validate fragment identifiers.
+     *
+     * @see RFC 3986: https://tools.ietf.org/html/rfc3986#section-3.5
+     */
+    const FRAGMENT_IDENTIFIER_REGEX = '/^([!$&\'()*+,;=._~:@\/?-]|%[0-9a-fA-F]{2}|[a-zA-Z0-9])+$/';
+
     /**
      * @var string
      */
@@ -41,16 +48,24 @@ class UrlHelper
      * Generate a URL based on a given route.
      *
      * @param string $routeName
-     * @param array $params
+     * @param array  $routeParams
+     * @param array  $queryParams
+     * @param string $fragmentIdentifier
+     * @param array  $options       Can have the following keys:
+     *                              - router (array): contains options to be passed to the router
+     *                              - reuse_result_params (bool): indicates if the current RouteResult
+     *                              parameters will be used, defaults to true
+     *
      * @return string
-     * @throws Exception\RuntimeException if no route provided, and no result match
-     *     present.
-     * @throws Exception\RuntimeException if no route provided, and result match is a
-     *     routing failure.
-     * @throws RouterException if router cannot generate URI for given route.
+     * @throws \Zend\Expressive\Helper\Exception\RuntimeException
      */
-    public function __invoke($routeName = null, array $params = [])
-    {
+    public function __invoke(
+        $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        $fragmentIdentifier = null,
+        array $options = []
+    ) {
         $result = $this->getRouteResult();
         if ($routeName === null && $result === null) {
             throw new Exception\RuntimeException(
@@ -63,15 +78,38 @@ class UrlHelper
             $basePath = '';
         }
 
+        // Get the options to be passed to the router
+        $routerOptions = array_key_exists('router', $options) ? $options['router'] : [];
+
         if ($routeName === null) {
-            return $basePath . $this->generateUriFromResult($params, $result);
+            return $basePath . $this->generateUriFromResult($routeParams, $result, $routerOptions);
         }
 
-        if ($result) {
-            $params = $this->mergeParams($routeName, $result, $params);
+        $reuseResultParams = !isset($options['reuse_result_params']) || (bool) $options['reuse_result_params'];
+
+        if ($result && $reuseResultParams) {
+            // Merge RouteResult with the route parameters
+            $routeParams = $this->mergeParams($routeName, $result, $routeParams);
         }
 
-        return $basePath . $this->router->generateUri($routeName, $params);
+        // Generate the route
+        $path = $basePath . $this->router->generateUri($routeName, $routeParams, $routerOptions);
+
+        // Append query parameters if there are any
+        if (count($queryParams) > 0) {
+            $path .= '?' . http_build_query($queryParams);
+        }
+
+        // Append the fragment identifier
+        if ($fragmentIdentifier !== null) {
+            if (!preg_match(self::FRAGMENT_IDENTIFIER_REGEX, $fragmentIdentifier)) {
+                throw new \InvalidArgumentException('Fragment identifier must conform to RFC 3986', 400);
+            }
+
+            $path .= '#' . $fragmentIdentifier;
+        }
+
+        return $path;
     }
 
     /**
@@ -79,18 +117,16 @@ class UrlHelper
      *
      * Proxies to __invoke().
      *
-     * @param string $route
-     * @param array $params
-     * @return string
-     * @throws Exception\RuntimeException if no route provided, and no result match
-     *     present.
-     * @throws Exception\RuntimeException if no route provided, and result match is a
-     *     routing failure.
-     * @throws RouterException if router cannot generate URI for given route.
+     * @see UrlHelper::__invoke()
      */
-    public function generate($route = null, array $params = [])
-    {
-        return $this($route, $params);
+    public function generate(
+        $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        $fragmentIdentifier = '',
+        array $options = []
+    ) {
+        return $this($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
     /**
@@ -144,10 +180,11 @@ class UrlHelper
     /**
      * @param array $params
      * @param RouteResult $result
+     * @param array $routerOptions
      * @return string
      * @throws RenderingException if current result is a routing failure.
      */
-    private function generateUriFromResult(array $params, RouteResult $result)
+    private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions)
     {
         if ($result->isFailure()) {
             throw new Exception\RuntimeException(
@@ -157,7 +194,7 @@ class UrlHelper
 
         $name   = $result->getMatchedRouteName();
         $params = array_merge($result->getMatchedParams(), $params);
-        return $this->router->generateUri($name, $params);
+        return $this->router->generateUri($name, $params, $routerOptions);
     }
 
     /**

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -85,7 +85,7 @@ class UrlHelper
             return $basePath . $this->generateUriFromResult($routeParams, $result, $routerOptions);
         }
 
-        $reuseResultParams = !isset($options['reuse_result_params']) || (bool) $options['reuse_result_params'];
+        $reuseResultParams = ! isset($options['reuse_result_params']) || (bool) $options['reuse_result_params'];
 
         if ($result && $reuseResultParams) {
             // Merge RouteResult with the route parameters
@@ -102,7 +102,7 @@ class UrlHelper
 
         // Append the fragment identifier
         if ($fragmentIdentifier !== null) {
-            if (!preg_match(self::FRAGMENT_IDENTIFIER_REGEX, $fragmentIdentifier)) {
+            if (! preg_match(self::FRAGMENT_IDENTIFIER_REGEX, $fragmentIdentifier)) {
                 throw new \InvalidArgumentException('Fragment identifier must conform to RFC 3986', 400);
             }
 

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -9,13 +9,12 @@
 
 namespace ZendTest\Expressive\Helper;
 
-use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Helper\Exception\RuntimeException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class UrlHelperTest extends TestCase
 {
@@ -48,7 +47,7 @@ class UrlHelperTest extends TestCase
 
     public function testRaisesExceptionOnInvocationIfRouterCannotGenerateUriForRouteProvided()
     {
-        $this->router->generateUri('foo', [])->willThrow(RouterException::class);
+        $this->router->generateUri('foo', [], [])->willThrow(RouterException::class);
         $helper = $this->createHelper();
         $this->setExpectedException(RouterException::class);
         $helper('foo');
@@ -61,7 +60,7 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('foo');
         $result->getMatchedParams()->willReturn(['bar' => 'baz']);
 
-        $this->router->generateUri('foo', ['bar' => 'baz'])->willReturn('URL');
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
@@ -76,7 +75,7 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('foo');
         $result->getMatchedParams()->willReturn(['bar' => 'baz']);
 
-        $this->router->generateUri('foo', ['bar' => 'baz', 'baz' => 'bat'])->willReturn('URL');
+        $this->router->generateUri('foo', ['bar' => 'baz', 'baz' => 'bat'], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
@@ -86,7 +85,7 @@ class UrlHelperTest extends TestCase
 
     public function testWhenRouteProvidedTheHelperDelegatesToTheRouterToGenerateUrl()
     {
-        $this->router->generateUri('foo', ['bar' => 'baz'])->willReturn('URL');
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('URL');
         $helper = $this->createHelper();
         $this->assertEquals('URL', $helper('foo', ['bar' => 'baz']));
     }
@@ -98,7 +97,7 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('not-resource');
         $result->getMatchedParams()->shouldNotBeCalled();
 
-        $this->router->generateUri('resource', [])->willReturn('URL');
+        $this->router->generateUri('resource', [], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
@@ -113,7 +112,7 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('resource');
         $result->getMatchedParams()->willReturn(['id' => 1]);
 
-        $this->router->generateUri('resource', ['id' => 1, 'version' => 2])->willReturn('URL');
+        $this->router->generateUri('resource', ['id' => 1, 'version' => 2], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
@@ -128,12 +127,27 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('resource');
         $result->getMatchedParams()->willReturn(['id' => 1]);
 
-        $this->router->generateUri('resource', ['id' => 2])->willReturn('URL');
+        $this->router->generateUri('resource', ['id' => 2], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
 
         $this->assertEquals('URL', $helper('resource', ['id' => 2]));
+    }
+
+    public function testWillNotReuseRouteResultParamsIfReuseResultParamsFlagIsFalseWhenGeneratingUri()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->isFailure()->willReturn(false);
+        $result->getMatchedRouteName()->willReturn('resource');
+        $result->getMatchedParams()->willReturn(['id' => 1]);
+
+        $this->router->generateUri('resource', [], [])->willReturn('URL');
+
+        $helper = $this->createHelper();
+        $helper->setRouteResult($result->reveal());
+
+        $this->assertEquals('URL', $helper('resource', [], [], null, ['reuse_result_params' => false]));
     }
 
     public function testCanInjectRouteResult()
@@ -160,7 +174,7 @@ class UrlHelperTest extends TestCase
 
     public function testBasePathIsPrependedToGeneratedPath()
     {
-        $this->router->generateUri('foo', ['bar' => 'baz'])->willReturn('/foo/baz');
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
         $helper->setBasePath('/prefix');
         $this->assertEquals('/prefix/foo/baz', $helper('foo', ['bar' => 'baz']));
@@ -173,7 +187,7 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('foo');
         $result->getMatchedParams()->willReturn(['bar' => 'baz']);
 
-        $this->router->generateUri('foo', ['bar' => 'baz'])->willReturn('/foo/baz');
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
 
         $helper = $this->createHelper();
         $helper->setBasePath('/prefix');
@@ -188,16 +202,22 @@ class UrlHelperTest extends TestCase
 
     public function testGenerateProxiesToInvokeMethod()
     {
-        $route = 'foo';
-        $params = ['bar'];
+        $routeName = 'foo';
+        $routeParams = ['bar'];
+        $queryParams = ['foo' => 'bar'];
+        $fragmentIdentifier = 'foobar';
+        $options = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
 
         $helper = \Mockery::mock(UrlHelper::class)->shouldDeferMissing();
         $helper->shouldReceive('__invoke')
             ->once()
-            ->with($route, $params)
+            ->with($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options)
             ->andReturn('it worked');
 
-        $this->assertSame('it worked', $helper->generate($route, $params));
+        $this->assertSame(
+            'it worked',
+            $helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options)
+        );
     }
 
     public function invalidBasePathProvider()
@@ -229,11 +249,67 @@ class UrlHelperTest extends TestCase
         $result->getMatchedRouteName()->willReturn('resource');
         $result->getMatchedParams()->shouldNotBeCalled();
 
-        $this->router->generateUri('resource', [])->willReturn('URL');
+        $this->router->generateUri('resource', [], [])->willReturn('URL');
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result->reveal());
 
         $this->assertEquals('URL', $helper('resource'));
+    }
+
+    public function testOptionsArePassedToRouter()
+    {
+        $this->router->generateUri('foo', [], ['bar' => 'baz'])->willReturn('URL');
+        $helper = $this->createHelper();
+        $this->assertEquals('URL', $helper('foo', [], [], null, ['router' => ['bar' => 'baz']]));
+    }
+
+    public function queryParametersAndFragmentProvider()
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            'none'           => [[], null, ''],
+            'query'          => [['qux' => 'quux'], null, '?qux=quux'],
+            'fragment'       => [[], 'corge', '#corge'],
+            'query+fragment' => [['qux' => 'quux'], 'cor-ge', '?qux=quux#cor-ge'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider queryParametersAndFragmentProvider
+     */
+    public function testQueryParametersAndFragment(array $queryParams, $fragmentIdentifier, $expected)
+    {
+        $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
+        $helper = $this->createHelper();
+
+        $this->assertEquals(
+            '/foo/baz' . $expected,
+            $helper('foo', ['bar' => 'baz'], $queryParams, $fragmentIdentifier)
+        );
+    }
+
+    public function invalidFragmentProvider()
+    {
+        return [
+            [''],
+            ['#'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidFragmentProvider
+     */
+    public function testRejectsInvalidFragmentIdentifier($fragmentIdentifier)
+    {
+        $this->setExpectedException(
+            \InvalidArgumentException::class,
+            'Fragment identifier must conform to RFC 3986',
+            400
+        );
+
+        $helper = $this->createHelper();
+        $helper('foo', [], [], $fragmentIdentifier);
     }
 }


### PR DESCRIPTION
@weierophinney as is the case with [zend-expressive-helpers@2.0.0](https://github.com/zendframework/zend-expressive-router/pull/31), I'd greatly appreciate a sanity check on this before releasing `3.0.0`.

**Process after 👍 :**

1. Rebase to update `CHANGELOG.md` from e606699 to reflect what the actual release date will be.
2. Rebase with upstream/master and force-push the updated `master` to my fork (which will update this pull request).
3. Merge the pull request.
4. Tag `3.0.0` off of whatever the new commit hash for e606699 ends up being.
5. Follow the remaining release steps to bring develop into sync with master.
6. Delete the dev-3.0.0 branch.

End result should be that `3.0.0` is released, `develop` and `master` are in sync, `dev-3.0.0` is deleted, and there is no unreleased code in any branch or PR (at the time this PR was submitted).

Make sense?