### PR TITLE
Ensure that generate() default arguments match those of __invoke()

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -123,7 +123,7 @@ class UrlHelper
         $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = '',
+        $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -310,4 +310,19 @@ class UrlHelperTest extends TestCase
         $helper = $this->createHelper();
         $helper('foo', [], [], $fragmentIdentifier);
     }
+
+    /**
+     * Test written when discovering that generate() uses '' as the default fragment,
+     * which __invoke() considers invalid.
+     */
+    public function testCallingGenerateWithoutFragmentArgumentPassesNullValueForFragment()
+    {
+        $this->router->generateUri('foo', [], [])->willReturn('/foo');
+        $helper = $this->createHelper();
+
+        $this->assertEquals(
+            '/foo',
+            $helper->generate('foo')
+        );
+    }
 }


### PR DESCRIPTION
Prior to this patch, `generate()` was setting the default argument for the `$fragment` argument to `''`, while `__invoke()` was setting it to `null`. The issue is that `''` is considered an invalid fragment, and `__invoke()` specifically tests for a `null` value before validating a fragment.

This patch updates the `generate()` signature to match that of `__invoke()`, solving the issue.

(Found when testing zendframework/zend-expressive-skeleton#54 against the new zend-expressive-helpers version.)