### PR TITLE
Added support for `http-interop/http-middleware` 0.5.0 (No BC Break)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,18 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        }
+    ],
     "require": {
-        "http-interop/http-middleware": "^0.4.1",
         "php": "^5.6 || ^7.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.1"
+        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "zendframework/zend-expressive-router": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2f0e9d74f60a5c2f67c2dbab0fa3a17",
+    "content-hash": "171318928480d72a91f04a20dbee93ca",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -208,28 +208,68 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "zendframework/zend-expressive-router",
-            "version": "2.1.0",
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79"
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/88d711aee740ac8fbd684472469e16b85435cc79",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
                 "shasum": ""
             },
             "require": {
-                "fig/http-message-util": "^1.1",
-                "http-interop/http-middleware": "^0.4.1",
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
+        },
+        {
+            "name": "zendframework/zend-expressive-router",
+            "version": "dev-feature/http-middleware-0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
+                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.2",
                 "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0.1",
+                "webimpress/http-middleware-compatibility": "^0.1.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.7 || ^5.6",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -249,7 +289,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -261,7 +330,10 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-24T22:28:12+00:00"
+            "support": {
+                "source": "https://github.com/webimpress/zend-expressive-router/tree/feature/http-middleware-0.5"
+            },
+            "time": "2017-10-05T16:20:19+00:00"
         }
     ],
     "packages-dev": [
@@ -2118,7 +2190,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-router": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -7,10 +7,12 @@
 
 namespace Zend\Expressive\Helper\BodyParams;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class BodyParamsMiddleware implements MiddlewareInterface
 {
@@ -77,7 +79,7 @@ class BodyParamsMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         if (in_array($request->getMethod(), $this->nonBodyRequests)) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         $header = $request->getHeaderLine('Content-Type');
@@ -87,10 +89,10 @@ class BodyParamsMiddleware implements MiddlewareInterface
             }
 
             // Matched! Parse and pass on to the next
-            return $delegate->process($strategy->parse($request));
+            return $delegate->{HANDLER_METHOD}($strategy->parse($request));
         }
 
         // No match; continue
-        return $delegate->process($request);
+        return $delegate->{HANDLER_METHOD}($request);
     }
 }

--- a/src/ContentLengthMiddleware.php
+++ b/src/ContentLengthMiddleware.php
@@ -7,9 +7,11 @@
 
 namespace Zend\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Middleware to inject a Content-Length response header.
@@ -25,7 +27,7 @@ class ContentLengthMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
-        $response = $delegate->process($request);
+        $response = $delegate->{HANDLER_METHOD}($request);
         if ($response->hasHeader('Content-Length')) {
             return $response;
         }

--- a/src/ServerUrlMiddleware.php
+++ b/src/ServerUrlMiddleware.php
@@ -7,10 +7,12 @@
 
 namespace Zend\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ServerUrlMiddleware implements MiddlewareInterface
 {
@@ -42,6 +44,6 @@ class ServerUrlMiddleware implements MiddlewareInterface
     {
         $this->helper->setUri($request->getUri());
 
-        return $delegate->process($request);
+        return $delegate->{HANDLER_METHOD}($request);
     }
 }

--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -7,11 +7,13 @@
 
 namespace Zend\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Router\RouteResult;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Pipeline middleware for injecting a UrlHelper with a RouteResult.
@@ -49,6 +51,6 @@ class UrlHelperMiddleware implements MiddlewareInterface
             $this->helper->setRouteResult($result);
         }
 
-        return $delegate->process($request);
+        return $delegate->{HANDLER_METHOD}($request);
     }
 }

--- a/test/BodyParams/BodyParamsMiddlewareTest.php
+++ b/test/BodyParams/BodyParamsMiddlewareTest.php
@@ -7,16 +7,18 @@
 
 namespace ZendTest\Expressive\Helper\BodyParams;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
 use Zend\Expressive\Helper\BodyParams\BodyParamsMiddleware;
 use Zend\Expressive\Helper\BodyParams\StrategyInterface;
 use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class BodyParamsMiddlewareTest extends TestCase
 {
@@ -46,7 +48,7 @@ class BodyParamsMiddlewareTest extends TestCase
         $delegate = $this->prophesize(DelegateInterface::class);
 
         $delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->will(function ($args) use ($callback) {
                 $request = $args[0];
                 return $callback($request);
@@ -60,7 +62,7 @@ class BodyParamsMiddlewareTest extends TestCase
         $delegate = $this->prophesize(DelegateInterface::class);
 
         $delegate
-            ->process(Argument::type(ServerRequestInterface::class))
+            ->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->shouldNotBeCalled();
 
         return $delegate;

--- a/test/ContentLengthMiddlewareTest.php
+++ b/test/ContentLengthMiddlewareTest.php
@@ -7,12 +7,14 @@
 
 namespace ZendTest\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Helper\ContentLengthMiddleware;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ContentLengthMiddlewareTest extends TestCase
 {
@@ -23,7 +25,7 @@ class ContentLengthMiddlewareTest extends TestCase
         $this->stream = $this->prophesize(StreamInterface::class);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request)->will([$response, 'reveal']);
+        $delegate->{HANDLER_METHOD}($request)->will([$response, 'reveal']);
         $this->delegate = $delegate->reveal();
 
         $this->middleware = new ContentLengthMiddleware();

--- a/test/ServerUrlMiddlewareTest.php
+++ b/test/ServerUrlMiddlewareTest.php
@@ -7,15 +7,17 @@
 
 namespace ZendTest\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\ServerUrlMiddleware;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ServerUrlMiddlewareTest extends TestCase
 {
@@ -31,7 +33,7 @@ class ServerUrlMiddlewareTest extends TestCase
         $invoked = false;
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(RequestInterface::class))->will(function ($req) use (&$invoked) {
+        $delegate->{HANDLER_METHOD}(Argument::type(RequestInterface::class))->will(function ($req) use (&$invoked) {
             $invoked = true;
 
             return new Response();

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -7,16 +7,17 @@
 
 namespace ZendTest\Expressive\Helper;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Helper\UrlHelperMiddleware;
 use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class UrlHelperMiddlewareTest extends TestCase
 {
@@ -43,7 +44,7 @@ class UrlHelperMiddlewareTest extends TestCase
         $this->helper->setRouteResult($routeResult)->shouldBeCalled();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(RequestInterface::class))->will(function ($req) {
+        $delegate->{HANDLER_METHOD}(Argument::type(RequestInterface::class))->will(function ($req) {
             return 'COMPLETE';
         });
 
@@ -61,7 +62,7 @@ class UrlHelperMiddlewareTest extends TestCase
         $this->helper->setRouteResult(Argument::any())->shouldNotBeCalled();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(RequestInterface::class))->will(function ($req) {
+        $delegate->{HANDLER_METHOD}(Argument::type(RequestInterface::class))->will(function ($req) {
             return 'COMPLETE';
         });
 


### PR DESCRIPTION
We keep also support for previosu version. It is accomplished by `webimpress/http-middleware-compatibility` repository, which allow to use any version of http-middleware. Consumer of the library can decide what version of http-middleware to use, and can easily migrate to the latest version at any time.

**Requires https://github.com/zendframework/zend-expressive-router/pull/36 to be merged before and released. Then `composer.json` in this PR should be updated.**