### PR TITLE
Adopt PHP 7.1 features

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,7 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     },
     "require": {
         "php": "^7.1",
+        "http-interop/http-server-middleware": "^1.0.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "http-interop/http-server-middleware": "^1.0.1",
         "zendframework/zend-expressive-router": "^3.0.0@dev"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3eb21f2a2d3b177c09af345a2a68a30",
+    "content-hash": "04df08428b88d8bd499233410fd4e45f",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -46,21 +46,16 @@ class BodyParamsMiddleware implements MiddlewareInterface
 
     /**
      * Add a body parsing strategy to the middleware.
-     *
-     * @param StrategyInterface $strategy
-     * @return void
      */
-    public function addStrategy(StrategyInterface $strategy)
+    public function addStrategy(StrategyInterface $strategy) : void
     {
         $this->strategies[] = $strategy;
     }
 
     /**
      * Clear all strategies from the middleware.
-     *
-     * @return void
      */
-    public function clearStrategies()
+    public function clearStrategies() : void
     {
         $this->strategies = [];
     }

--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\BodyParams;
 

--- a/src/BodyParams/FormUrlEncodedStrategy.php
+++ b/src/BodyParams/FormUrlEncodedStrategy.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\BodyParams;
 
@@ -11,18 +13,12 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class FormUrlEncodedStrategy implements StrategyInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function match($contentType)
+    public function match(string $contentType) : bool
     {
         return (bool) preg_match('#^application/x-www-form-urlencoded($|[ ;])#', $contentType);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function parse(ServerRequestInterface $request)
+    public function parse(ServerRequestInterface $request) : ServerRequestInterface
     {
         $parsedBody = $request->getParsedBody();
 

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\BodyParams;
 
@@ -12,10 +14,7 @@ use Zend\Expressive\Helper\Exception\MalformedRequestBodyException;
 
 class JsonStrategy implements StrategyInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function match($contentType)
+    public function match(string $contentType) : bool
     {
         $parts = explode(';', $contentType);
         $mime = array_shift($parts);
@@ -27,7 +26,7 @@ class JsonStrategy implements StrategyInterface
      *
      * @throws MalformedRequestBodyException
      */
-    public function parse(ServerRequestInterface $request)
+    public function parse(ServerRequestInterface $request) : ServerRequestInterface
     {
         $rawBody = (string) $request->getBody();
         $parsedBody = json_decode($rawBody, true);

--- a/src/BodyParams/StrategyInterface.php
+++ b/src/BodyParams/StrategyInterface.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\BodyParams;
 
@@ -17,10 +19,9 @@ interface StrategyInterface
     /**
      * Match the content type to the strategy criteria.
      *
-     * @param string $contentType
      * @return bool Whether or not the strategy matches.
      */
-    public function match($contentType);
+    public function match(string $contentType) : bool;
 
     /**
      * Parse the body content and return a new request.
@@ -28,5 +29,5 @@ interface StrategyInterface
      * @param ServerRequestInterface $request
      * @return ServerRequestInterface
      */
-    public function parse(ServerRequestInterface $request);
+    public function parse(ServerRequestInterface $request) : ServerRequestInterface;
 }

--- a/src/ContentLengthMiddleware.php
+++ b/src/ContentLengthMiddleware.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\Exception;
 

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\Exception;
 

--- a/src/Exception/MissingHelperException.php
+++ b/src/Exception/MissingHelperException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\Exception;
 

--- a/src/Exception/MissingRouterException.php
+++ b/src/Exception/MissingRouterException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\Exception;
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper\Exception;
 

--- a/src/ServerUrlHelper.php
+++ b/src/ServerUrlHelper.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -32,12 +34,11 @@ class ServerUrlHelper
      *
      * The $path may optionally contain the query string and/or fragment to
      * use.
-     *
-     * @param null|string $path
-     * @return string
      */
-    public function __invoke($path = null)
+    public function __invoke(string $path = null) : string
     {
+        $path = $path === null ? '' : $path;
+
         if ($this->uri instanceof UriInterface) {
             return $this->createUrlFromUri($path);
         }
@@ -57,29 +58,18 @@ class ServerUrlHelper
      * Generate a path relative to the current request URI.
      *
      * Proxies to __invoke().
-     *
-     * @param null|string $path
-     * @return string
      */
-    public function generate($path = null)
+    public function generate(string $path = null) : string
     {
         return $this($path);
     }
 
-    /**
-     * @param UriInterface $uri
-     * @return void
-     */
-    public function setUri(UriInterface $uri)
+    public function setUri(UriInterface $uri) : void
     {
         $this->uri = $uri;
     }
 
-    /**
-     * @param string $specification
-     * @return string
-     */
-    private function createUrlFromUri($specification)
+    private function createUrlFromUri(string $specification) : string
     {
         preg_match(
             '%^(?P<path>[^?#]*)(?:(?:\?(?P<query>[^#]*))?(?:\#(?P<fragment>.*))?)$%',

--- a/src/ServerUrlMiddleware.php
+++ b/src/ServerUrlMiddleware.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 

--- a/src/ServerUrlMiddleware.php
+++ b/src/ServerUrlMiddleware.php
@@ -19,9 +19,6 @@ class ServerUrlMiddleware implements MiddlewareInterface
      */
     private $helper;
 
-    /**
-     * @param ServerUrlHelper $helper
-     */
     public function __construct(ServerUrlHelper $helper)
     {
         $this->helper = $helper;
@@ -35,7 +32,6 @@ class ServerUrlMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $this->helper->setUri($request->getUri());
-
         return $handler->handle($request);
     }
 }

--- a/src/ServerUrlMiddlewareFactory.php
+++ b/src/ServerUrlMiddlewareFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -14,11 +16,9 @@ class ServerUrlMiddlewareFactory
     /**
      * Create a ServerUrlMiddleware instance.
      *
-     * @param ContainerInterface $container
-     * @return ServerUrlMiddleware
      * @throws Exception\MissingHelperException
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : ServerUrlMiddleware
     {
         if (! $container->has(ServerUrlHelper::class)) {
             throw new Exception\MissingHelperException(sprintf(

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -46,25 +48,23 @@ class UrlHelper
     /**
      * Generate a URL based on a given route.
      *
-     * @param null|string $routeName
-     * @param array $routeParams
-     * @param array $queryParams
-     * @param null|string $fragmentIdentifier
      * @param array $options Can have the following keys:
-     *                         - router (array): contains options to be passed to the router
-     *                         - reuse_result_params (bool): indicates if the current RouteResult
-     *                         parameters will be used, defaults to true
-     * @return string
-     * @throws Exception\RuntimeException
-     * @throws InvalidArgumentException
+     *     - router (array): contains options to be passed to the router
+     *     - reuse_result_params (bool): indicates if the current RouteResult
+     *       parameters will be used, defaults to true
+     * @throws Exception\RuntimeException for attempts to use the currently matched
+     *     route but routing failed.
+     * @throws Exception\RuntimeException for attempts to use a matched result
+     *     when none has been previously injected in the instance.
+     * @throws InvalidArgumentException for malformed fragment identifiers.
      */
     public function __invoke(
-        $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
-    ) {
+    ) : string {
         $result = $this->getRouteResult();
         if ($routeName === null && $result === null) {
             throw new Exception\RuntimeException(
@@ -110,21 +110,14 @@ class UrlHelper
      * Proxies to __invoke().
      *
      * @see UrlHelper::__invoke()
-     *
-     * @param null|string $routeName
-     * @param array $routeParams
-     * @param array $queryParams
-     * @param null|string $fragmentIdentifier
-     * @param array $options
-     * @return string
      */
     public function generate(
-        $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
-    ) {
+    ) : string {
         return $this($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
@@ -133,62 +126,40 @@ class UrlHelper
      *
      * When the route result is injected, the helper will use it to seed default
      * parameters if the URL being generated is for the route that was matched.
-     *
-     * @param RouteResult $result
-     * @return void
      */
-    public function setRouteResult(RouteResult $result)
+    public function setRouteResult(RouteResult $result) : void
     {
         $this->result = $result;
     }
 
     /**
      * Set the base path to prepend to a generated URI
-     *
-     * @param mixed $path
-     * @return void
-     * @throws InvalidArgumentException
      */
-    public function setBasePath($path)
+    public function setBasePath(string $path) : void
     {
-        if (! is_string($path)) {
-            throw new InvalidArgumentException(sprintf(
-                'Base path must be a string; received %s',
-                is_object($path) ? get_class($path) : gettype($path)
-            ));
-        }
-
         $this->basePath = '/' . ltrim($path, '/');
     }
 
     /**
      * Internal accessor for retrieving the route result.
-     *
-     * @return null|RouteResult
      */
-    protected function getRouteResult()
+    protected function getRouteResult() : ?RouteResult
     {
         return $this->result;
     }
 
     /**
      * Internal accessor for retrieving the base path.
-     *
-     * @return string
      */
-    public function getBasePath()
+    public function getBasePath() : string
     {
         return $this->basePath;
     }
 
     /**
-     * @param array $params
-     * @param RouteResult $result
-     * @param array $routerOptions
-     * @return string
      * @throws Exception\RuntimeException if current result is a routing failure.
      */
-    private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions)
+    private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions) : string
     {
         if ($result->isFailure()) {
             throw new Exception\RuntimeException(
@@ -214,11 +185,9 @@ class UrlHelper
      * invocation, with the latter having precedence.
      *
      * @param string $route Route name.
-     * @param RouteResult $result
      * @param array $params Parameters provided at invocation.
-     * @return array
      */
-    private function mergeParams($route, RouteResult $result, array $params)
+    private function mergeParams(string $route, RouteResult $result, array $params) : array
     {
         if ($result->isFailure()) {
             return $params;
@@ -233,12 +202,8 @@ class UrlHelper
 
     /**
      * Append query string arguments to a URI string, if any are present.
-     *
-     * @param string $uriString
-     * @param array $queryParams
-     * @return string
      */
-    private function appendQueryStringArguments($uriString, array $queryParams)
+    private function appendQueryStringArguments(string $uriString, array $queryParams) : string
     {
         if (count($queryParams) > 0) {
             return sprintf('%s?%s', $uriString, http_build_query($queryParams));
@@ -249,11 +214,9 @@ class UrlHelper
     /**
      * Append a fragment to a URI string, if present.
      *
-     * @param string $uriString
-     * @param null|string $fragmentIdentifier
-     * @return string
+     * @throws InvalidArgumentException if the fragment identifier is malformed.
      */
-    private function appendFragment($uriString, $fragmentIdentifier)
+    private function appendFragment(string $uriString, ?string $fragmentIdentifier) : string
     {
         if ($fragmentIdentifier !== null) {
             if (! preg_match(self::FRAGMENT_IDENTIFIER_REGEX, $fragmentIdentifier)) {

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -15,11 +17,9 @@ class UrlHelperFactory
     /**
      * Create a UrlHelper instance.
      *
-     * @param ContainerInterface $container
-     * @return UrlHelper
      * @throws Exception\MissingRouterException
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : UrlHelper
     {
         if (! $container->has(RouterInterface::class)) {
             throw new Exception\MissingRouterException(sprintf(

--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -23,9 +25,6 @@ class UrlHelperMiddleware implements MiddlewareInterface
      */
     private $helper;
 
-    /**
-     * @param UrlHelper $helper
-     */
     public function __construct(UrlHelper $helper)
     {
         $this->helper = $helper;

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Helper;
 
@@ -14,12 +16,10 @@ class UrlHelperMiddlewareFactory
     /**
      * Create and return a UrlHelperMiddleware instance.
      *
-     * @param ContainerInterface $container
-     * @return UrlHelperMiddleware
      * @throws Exception\MissingHelperException if the UrlHelper service is
      *     missing
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container) : UrlHelperMiddleware
     {
         if (! $container->has(UrlHelper::class)) {
             throw new Exception\MissingHelperException(sprintf(

--- a/test/BodyParams/BodyParamsMiddlewareTest.php
+++ b/test/BodyParams/BodyParamsMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper\BodyParams;
 

--- a/test/BodyParams/FormUrlEncodedStrategyTest.php
+++ b/test/BodyParams/FormUrlEncodedStrategyTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper\BodyParams;
 

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper\BodyParams;
 

--- a/test/ContentLengthMiddlewareTest.php
+++ b/test/ContentLengthMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/ServerUrlMiddlewareFactoryTest.php
+++ b/test/ServerUrlMiddlewareFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/ServerUrlMiddlewareTest.php
+++ b/test/ServerUrlMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -11,7 +11,6 @@ use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Helper\UrlHelper;
@@ -37,20 +36,18 @@ class UrlHelperMiddlewareTest extends TestCase
 
     public function testInvocationInjectsHelperWithRouteResultWhenPresentInRequest()
     {
+        $response = $this->prophesize(ResponseInterface::class);
+
         $routeResult = $this->prophesize(RouteResult::class)->reveal();
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
         $this->helper->setRouteResult($routeResult)->shouldBeCalled();
 
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
-
         $handler = $this->prophesize(RequestHandlerInterface::class);
-        $handler->handle(Argument::type(RequestInterface::class))->will(function ($req) use ($response) {
-            return $response;
-        });
+        $handler->handle(Argument::type(ServerRequestInterface::class))->will([$response, 'reveal']);
 
         $middleware = $this->createMiddleware();
-        $this->assertSame($response, $middleware->process(
+        $this->assertSame($response->reveal(), $middleware->process(
             $request->reveal(),
             $handler->reveal()
         ));
@@ -58,19 +55,17 @@ class UrlHelperMiddlewareTest extends TestCase
 
     public function testInvocationDoesNotInjectHelperWithRouteResultWhenAbsentInRequest()
     {
+        $response = $this->prophesize(ResponseInterface::class);
+
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute(RouteResult::class, false)->willReturn(false);
         $this->helper->setRouteResult(Argument::any())->shouldNotBeCalled();
 
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
-
         $handler = $this->prophesize(RequestHandlerInterface::class);
-        $handler->handle(Argument::type(RequestInterface::class))->will(function ($req) use ($response) {
-            return $response;
-        });
+        $handler->handle(Argument::type(ServerRequestInterface::class))->will([$response, 'reveal']);
 
         $middleware = $this->createMiddleware();
-        $this->assertSame($response, $middleware->process(
+        $this->assertSame($response->reveal(), $middleware->process(
             $request->reveal(),
             $handler->reveal()
         ));

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Helper;
 
@@ -13,6 +15,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
+use TypeError;
 use Zend\Expressive\Helper\Exception\RuntimeException;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Router\Exception\RuntimeException as RouterException;
@@ -250,8 +253,7 @@ class UrlHelperTest extends TestCase
      */
     public function testThrowsExceptionWhenSettingInvalidBasePaths($basePath)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/^Base path must be a string; received [a-zA-Z]+/');
+        $this->expectException(TypeError::class);
 
         $helper = $this->createHelper();
         $helper->setBasePath($basePath);

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -326,6 +326,8 @@ class UrlHelperTest extends TestCase
         $this->expectExceptionMessage('Fragment identifier must conform to RFC 3986');
         $this->expectExceptionCode(400);
 
+        $this->router->generateUri('foo', [], [])->willReturn('/foo');
+
         $helper = $this->createHelper();
         $helper('foo', [], [], $fragmentIdentifier);
     }


### PR DESCRIPTION
This patch updates the component to make use of PHP 7.1 features. In particular:

- All signatures were updated to add return type hints, scalar type hints, and nullable types as necessary. The following signatures in particular are of interest due to backwards-incompatible changes:
  - `Zend\Expressive\Helper\BodyParams\StrategyInterface`:
      - The `match()` signature changes to `match(string $contentType) : bool`
      - The `parse()` signature changes to `parse(ServerRequestInterface $request) : ServerRequestInterface`
  - `Zend\Expressive\Helper\ServerUrlHelper` updates its public API to read as follows:
     - `__invoke(string $path = null) : string`
     - `generate(string $path = null) : string`
     - `setUri(UriInterface $uri) : void`
  - `Zend\Expressive\Helper\UrlHelper` updates its public API to read as follows:
     - `__invoke(?string $routeName = null, array $routeParams = [], array $queryParams = [], ?string $fragmentIdentifier = null, array $options = []) : string`
     - `generate(?string $routeName = null, array $routeParams = [], array $queryParams = [], ?string $fragmentIdentifier = null, array $options = []) : string`
     - `setRouteResult(RouteResult $result) : void`
     - `setBasePath(string $path) : void`
     - `getRouteResult() : ?RouteResult`
     - `getBasePath() : string`
- All class files enable `strict_types` to ensure errors are thrown for invalid scalar values.