### PR TITLE
Allow varying `UrlHelper` for path-segregated middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 5.1.0 - TBD
+## 5.1.0 - 2018-06-05
 
 ### Added
 
@@ -10,7 +10,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#62](https://github.com/zendframework/zend-expressive-helpers/pull/62) modifies the `UrlHelperFactory` to allow specifying both a string `$basePath` as well as a string `$routerServiceName`
+  to its constructor. This change allows having discrete factory instances for generating helpers
+  that use different router instances and/or which operate under path-segregated middleware.
+
+- [#62](https://github.com/zendframework/zend-expressive-helpers/pull/62) modifies the `UrlHelperMiddlewareFactory` to allow specifying a string `$urlHelperServiceName` to its constructor.
+  This change allows having discrete factory instances for generating URL helper middleware
+  that use different URL helper instances.
 
 ### Deprecated
 

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -16,6 +16,34 @@ use function sprintf;
 
 class UrlHelperFactory
 {
+    /** @var string Base path for the URL helper */
+    private $basePath;
+
+    /** @var string $routerServiceName */
+    private $routerServiceName;
+
+    /**
+     * Allow serialization
+     */
+    public static function __set_state(array $data) : self
+    {
+        return new self(
+            $data['basePath'] ?? '/',
+            $data['routerServiceName'] ?? RouterInterface::class
+        );
+    }
+
+    /**
+     * Allows varying behavior per-instance.
+     *
+     * Defaults to '/' for the base path, and the FQCN of the RouterInterface.
+     */
+    public function __construct(string $basePath = '/', string $routerServiceName = RouterInterface::class)
+    {
+        $this->basePath = $basePath;
+        $this->routerServiceName = $routerServiceName;
+    }
+
     /**
      * Create a UrlHelper instance.
      *
@@ -23,14 +51,16 @@ class UrlHelperFactory
      */
     public function __invoke(ContainerInterface $container) : UrlHelper
     {
-        if (! $container->has(RouterInterface::class)) {
+        if (! $container->has($this->routerServiceName)) {
             throw new Exception\MissingRouterException(sprintf(
                 '%s requires a %s implementation; none found in container',
                 UrlHelper::class,
-                RouterInterface::class
+                $this->routerServiceName
             ));
         }
 
-        return new UrlHelper($container->get(RouterInterface::class));
+        $helper = new UrlHelper($container->get($this->routerServiceName));
+        $helper->setBasePath($this->basePath);
+        return $helper;
     }
 }

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -15,6 +15,27 @@ use function sprintf;
 
 class UrlHelperMiddlewareFactory
 {
+    /** @var string */
+    private $urlHelperServiceName;
+
+    /**
+     * Allow serialization
+     */
+    public static function __set_state(array $data) : self
+    {
+        return new self(
+            $data['urlHelperServiceName'] ?? UrlHelper::class
+        );
+    }
+
+    /**
+     * Allow varying behavior based on URL helper service name.
+     */
+    public function __construct(string $urlHelperServiceName = UrlHelper::class)
+    {
+        $this->urlHelperServiceName = $urlHelperServiceName;
+    }
+
     /**
      * Create and return a UrlHelperMiddleware instance.
      *
@@ -23,14 +44,14 @@ class UrlHelperMiddlewareFactory
      */
     public function __invoke(ContainerInterface $container) : UrlHelperMiddleware
     {
-        if (! $container->has(UrlHelper::class)) {
+        if (! $container->has($this->urlHelperServiceName)) {
             throw new Exception\MissingHelperException(sprintf(
                 '%s requires a %s service at instantiation; none found',
                 UrlHelperMiddleware::class,
-                UrlHelper::class
+                $this->urlHelperServiceName
             ));
         }
 
-        return new UrlHelperMiddleware($container->get(UrlHelper::class));
+        return new UrlHelperMiddleware($container->get($this->urlHelperServiceName));
     }
 }

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -54,4 +54,26 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $this->expectException(MissingHelperException::class);
         $factory($this->container->reveal());
     }
+
+    public function testFactoryUsesUrlHelperServiceProvidedAtInstantiation()
+    {
+        $helper = $this->prophesize(UrlHelper::class)->reveal();
+        $this->injectContainer(MyUrlHelper::class, $helper);
+        $factory = new UrlHelperMiddlewareFactory(MyUrlHelper::class);
+
+        $middleware = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(UrlHelperMiddleware::class, $middleware);
+        $this->assertAttributeSame($helper, 'helper', $middleware);
+    }
+
+    public function testFactoryAllowsSerialization()
+    {
+        $factory = UrlHelperMiddlewareFactory::__set_state([
+            'urlHelperServiceName' => MyUrlHelper::class,
+        ]);
+
+        $this->assertInstanceOf(UrlHelperMiddlewareFactory::class, $factory);
+        $this->assertAttributeSame(MyUrlHelper::class, 'urlHelperServiceName', $factory);
+    }
 }


### PR DESCRIPTION
When creating path-segregated middleware, you may want to provide middleware-specific routing. Once you do that, however, you need a new `UrlHelper` instance that contains that new router, and which knows the base path to prepend, if you want to generate route-specific URIs.

This patch is the first of several that accommodates this scenario.

The approach it uses is to allow optional constructor arguments to each of the `UrlHelperFactory` and `UrlHelperMiddlewareFactory`. Usage is as follows:

```php
// in a ConfigProvider or config file:
namespace Api;

use Zend\Expressive\Helper\UrlHelperFactory;
use Zend\Expressive\Helper\UrlHelperMiddlewareFactory;
use Zend\Expressive\Router\FastRouteRouter;

return [
    'dependencies' => [
        'factories' => [
            Router::class => FastRouteRouter::class,
            UrlHelper::class => new UrlHelperFactory('/api', Router::class),
            UrlHelperMiddleware::class => new UrlHelperMiddlewareFactory(UrlHelper::class),
        ],
    ],
];
```

In the above, `Router:class`, `UrlHelper::class`, and `UrlHelperMiddleware::class` are virtual services, resolving to the `Api` namespace. When creating our middleware pipeline, we can now reference the `UrlHelperMiddleware` service:

```php
$app->pipe('/api', [
    Api\UrlHelperMiddleware::class,
    // ...
]);
```

Each factory now also implements `__set_state()`, to ensure that configuration caching will work correctly (the default configuration caching uses `var_export()`, which requires that `__set_state()` be defined when `include` is called).