### PR TITLE
#63 no json_decode() call if request body is empty

### DIFF
--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -40,9 +40,16 @@ class JsonStrategy implements StrategyInterface
     public function parse(ServerRequestInterface $request) : ServerRequestInterface
     {
         $rawBody = (string) $request->getBody();
+
+        if (empty($rawBody)) {
+            return $request
+                ->withAttribute('rawBody', $rawBody)
+                ->withParsedBody(null);
+        }
+
         $parsedBody = json_decode($rawBody, true);
 
-        if (! empty($rawBody) && json_last_error() !== JSON_ERROR_NONE) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             throw new MalformedRequestBodyException(sprintf(
                 'Error when parsing JSON request body: %s',
                 json_last_error_msg()

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -117,4 +117,24 @@ class JsonStrategyTest extends TestCase
 
         $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testEmptyRequestBodyIsNotJsonDecoded(): void
+    {
+        $body = '';
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->__toString()->willReturn($body);
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getBody()->willReturn($stream->reveal());
+        $request->withAttribute('rawBody', $body)->will(function () use ($request) {
+            return $request->reveal();
+        });
+        $request->withParsedBody(null)->will(function () use ($request) {
+            return $request->reveal();
+        });
+
+        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
+    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
