### PR TITLE
Provide stateless template variable aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 5.3.0 - TBD
+
+### Added
+
+- [#70](https://github.com/zendframework/zend-expressive-helpers/pull/70) adds `Zend\Expressive\Helper\Template\TemplateVariableContainer`, which
+  can be used to aggregate template variables within a pipeline, and as a
+  stateless alternative to using `TemplateRendererInterface::addDefaultParam()`.
+  Please review the `README.me` for more details.
+
+- [#70](https://github.com/zendframework/zend-expressive-helpers/pull/70) adds `Zend\Expressive\Helper\Template\TemplateVariableContainerMiddleware`,
+  which will register an empty `TemplateVariableContainer` under that class's name
+  as a request attribute, if one is not already present.
+
+- [#70](https://github.com/zendframework/zend-expressive-helpers/pull/70) adds `Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware`,
+  which will register the return value of any discovered `Zend\Expressive\Router\RouteResult`
+  request attribute's `getMatchedRoute()` method in the
+  `TemplateVariableContainer` request attribute, when present. This middleware
+  can be used in place of the `UrlHelperMiddleware`, as long as you **always**
+  provide the route name to the `UrlHelper`.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 5.2.0 - 2019-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#70](https://github.com/zendframework/zend-expressive-helpers/pull/70) adds `Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware`,
   which will register the return value of any discovered `Zend\Expressive\Router\RouteResult`
-  request attribute's `getMatchedRoute()` method in the
-  `TemplateVariableContainer` request attribute, when present. This middleware
-  can be used in place of the `UrlHelperMiddleware`, as long as you **always**
-  provide the route name to the `UrlHelper`.
+  request attribute as the "route" variable of a `TemplateVariableContainer`
+  request attribute, when present. This middleware can be used in place of the
+  `UrlHelperMiddleware`, as long as you **always** provide the route name to the
+  `UrlHelper`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ composer require zendframework/zend-expressive-helpers
 - [BodyParams middleware](#bodyparams-middleware)
 - [Content-Length middleware](#content-length-middleware)
 - [Template Variable Container](#template-variable-container)
+- [Route template variable middleware](#route-template-variable-middleware)
 
 ### UrlHelper
 
@@ -572,6 +573,27 @@ The `TemplateVariableContainer` contains the following methods:
 - `mergeForTemplate(array $values) : array`: merge `$values` with any values in
   the container, and return the result. This method has no side effects, and
   should be used when preparing variables to pass to the renderer.
+
+### Route template variable middleware
+
+> - Since 5.2.0
+
+`Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware` will inject
+the currently matched route into the [template variable container](#template-variable-container).
+
+This middleware relies on the `TemplateVariableContainerMiddleware` preceding
+it in the middleware pipeline, or having the `TemplateVariableContainer`
+request attribute present.
+
+If it finds a `Zend\Expressive\Router\RouteResult` request attribute, it will
+inject the return value of `getMatchedRoute()` under the name `route` in the
+template variable container.
+
+Templates rendered using the container can then access that value. It will
+either be a Zend\Expressive\Router\Route instance, or empty.
+
+This middleware can replace the [UrlHelperMiddleware](#urlhelper) in your
+pipeline.
 
 ## Documentation
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
  */
 
@@ -20,9 +20,12 @@ class ConfigProvider
 
     public function getDependencies() : array
     {
+        // @codingStandardsIgnoreStart
+        // phpcs:disable
         return [
             'invokables' => [
-                ServerUrlHelper::class => ServerUrlHelper::class,
+                ServerUrlHelper::class                              => ServerUrlHelper::class,
+                Template\TemplateVariableContainerMiddleware::class => Template\TemplateVariableContainerMiddleware::class,
             ],
             'factories'  => [
                 ServerUrlMiddleware::class => ServerUrlMiddlewareFactory::class,
@@ -30,5 +33,7 @@ class ConfigProvider
                 UrlHelperMiddleware::class => UrlHelperMiddlewareFactory::class,
             ],
         ];
+        // phpcs:enable
+        // @codingStandardsIgnoreEnd
     }
 }

--- a/src/Template/RouteTemplateVariableMiddleware.php
+++ b/src/Template/RouteTemplateVariableMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Helper\Template;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
+
+/**
+ * Inject the currently matched route into the template variable container.
+ *
+ * This middleware relies on the TemplateVariableContainerMiddleware preceding
+ * it in the middleware pipeline, or having the TemplateVariableContainer
+ * request attribute present.
+ *
+ * If it finds a RouteResult request attribute, it will inject the return
+ * value of `getMatchedRoute()` under the name `route` in the template variable
+ * container.
+ *
+ * Templates rendered using the container can then access that value. It will
+ * either be a Zend\Expressive\Router\Route instance, or empty.
+ *
+ * This middleware can replace the `UrlHelperMiddleware` in your pipeline.
+ */
+class RouteTemplateVariableMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $container = $request->getAttribute(TemplateVariableContainer::class);
+        if (! $container) {
+            return $handler->handle($request);
+        }
+
+        $routeResult = $request->getAttribute(RouteResult::class, null);
+        $route = $routeResult
+            ? $routeResult->getMatchedRoute()
+            : null;
+
+        $container->set('route', $route);
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Template/RouteTemplateVariableMiddleware.php
+++ b/src/Template/RouteTemplateVariableMiddleware.php
@@ -45,8 +45,9 @@ class RouteTemplateVariableMiddleware implements MiddlewareInterface
             ? $routeResult->getMatchedRoute()
             : null;
 
-        $container->set('route', $route);
-
-        return $handler->handle($request);
+        return $handler->handle($request->withAttribute(
+            TemplateVariableContainer::class,
+            $container->with('route', $route)
+        ));
     }
 }

--- a/src/Template/TemplateVariableContainer.php
+++ b/src/Template/TemplateVariableContainer.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Helper\Template;
+
+use Countable;
+
+/**
+ * Stateful container for managing template variables within a middleware pipeline.
+ *
+ * `Zend\Expressive\Template\TemplateRendererInterface::addDefaultParam()` alters
+ * the state of the renderer, which can be problematic in async environments.
+ * This class can be composed in a request attribute (we recommend one named
+ * after the class itself) in order to aggregate template variables prior to
+ * rendering. The class that renders a template (generally a handler, but
+ * potentially middleware) can then pull this container and use it to seed the
+ * template variables.
+ *
+ * Middleware that needs to populate one or more template variables can do the
+ * following:
+ *
+ * <code>
+ * $container = $request->getAttribute(
+ *     TemplateVariableContainer::class,
+ *     new TemplateVariableContainer()
+ * );
+ *
+ * // Populate a single variable:
+ * $container->set('user', $user);
+ *
+ * // Populate several variables:
+ * $container->merge([
+ *     'user'  => $user,
+ *     'roles' => $user->getRoles(),
+ * ]);
+ *
+ * return $handler->handle($request->withAttribute(
+ *     TemplateVariableContainer::class,
+ *     $container
+ * ));
+ * </code>
+ *
+ * In a handler or middleware that renders a template, pull the container, and
+ * use its mergeForTemplate() method when calling render():
+ *
+ * <code>
+ * $container = $request->getAttribute(
+ *     TemplateVariableContainer::class,
+ *     new TemplateVariableContainer()
+ * );
+ *
+ * $content = $this->renderer->render(
+ *     'some::template',
+ *     $container->mergeForTemplate([
+ *         'local' => 'value',
+ *     ])
+ * );
+ * </code>
+ */
+class TemplateVariableContainer implements Countable
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private $variables = [];
+
+    public function count() : int
+    {
+        return count($this->variables);
+    }
+
+    /**
+     * @return null|mixed Returns null if $key does not exist in container;
+     *     otherwise, returns value associated with $key
+     */
+    public function get(string $key)
+    {
+        return $this->variables[$key] ?? null;
+    }
+
+    public function has(string $key) : bool
+    {
+        return array_key_exists($key, $this->variables);
+    }
+
+    public function set(string $key, $value) : void
+    {
+        $this->variables[$key] = $value;
+    }
+
+    public function unset(string $key) : void
+    {
+        unset($this->variables[$key]);
+    }
+
+    /**
+     * Merge an array of values into the container.
+     *
+     * Use this method to populate many values in the container at once.
+     *
+     * This method will overwrite any existing value with the same key with the
+     * new value if it occurs in $values.
+     */
+    public function merge(array $values) : void
+    {
+        $this->variables = array_merge($this->variables, $values);
+    }
+
+    /**
+     * Merge a set of values with those in the container, and return the result.
+     *
+     * Use this method to merge handler-specific template values with those in
+     * the container in order to pass the result to the renderer's `render()`
+     * method.
+     */
+    public function mergeForTemplate(array $values) : array
+    {
+        return array_merge($this->variables, $values);
+    }
+}

--- a/src/Template/TemplateVariableContainerMiddleware.php
+++ b/src/Template/TemplateVariableContainerMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Helper\Template;
+
+use Psr\Http\Message\ResponseInterface;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Middleware for initializing the template variable container for the current request.
+ *
+ * If no template variable container exists yet in the request, this middleware
+ * will create one and inject it in the request passed to the handler.
+ *
+ * Otherwise, it does nothing.
+ *
+ * The middleware uses a key named after the container class.
+ */
+class TemplateVariableContainerMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $container = $request->getAttribute(TemplateVariableContainer::class);
+
+        if ($container instanceof TemplateVariableContainer) {
+            return $handler->handle($request);
+        }
+
+        $container = new TemplateVariableContainer();
+        return $handler->handle($request->withAttribute(
+            TemplateVariableContainer::class,
+            $container
+        ));
+    }
+}

--- a/test/Template/RouteTemplateVariableMiddlewareTest.php
+++ b/test/Template/RouteTemplateVariableMiddlewareTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Helper\Template;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware;
+use Zend\Expressive\Helper\Template\TemplateVariableContainer;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+class RouteTemplateVariableMiddlewareTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request    = $this->prophesize(ServerRequestInterface::class);
+        $this->response   = $this->prophesize(ResponseInterface::class);
+        $this->handler    = $this->prophesize(RequestHandlerInterface::class);
+        $this->container  = new TemplateVariableContainer();
+        $this->middleware = new RouteTemplateVariableMiddleware();
+    }
+
+    public function testMiddlewareIsANoOpIfNoVariableContainerPresent()
+    {
+        $this->request
+            ->getAttribute(TemplateVariableContainer::class)
+            ->willReturn(null)
+            ->shouldBeCalledTimes(1);
+
+        $this->request
+            ->getAttribute(RouteResult::class, null)
+            ->shouldNotBeCalled();
+
+        $this->handler
+            ->handle(Argument::that([$this->request, 'reveal']))
+            ->will([$this->response, 'reveal']);
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+    }
+
+    public function testMiddlewareWillInjectNullValueForRouteIfNoRouteResultInRequest()
+    {
+        $this->request
+            ->getAttribute(TemplateVariableContainer::class)
+            ->willReturn($this->container)
+            ->shouldBeCalledTimes(1);
+
+        $this->request
+            ->getAttribute(RouteResult::class, null)
+            ->willReturn(null)
+            ->shouldBeCalledTimes(1);
+
+        $this->handler
+            ->handle(Argument::that([$this->request, 'reveal']))
+            ->will([$this->response, 'reveal']);
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+
+        $this->assertTrue($this->container->has('route'));
+        $this->assertNull($this->container->get('route'));
+    }
+
+    public function routeTypes() : iterable
+    {
+        yield 'null'  => [null];
+        yield 'false' => [false];
+
+        $route = $this->prophesize(Route::class)->reveal();
+        yield 'route' => [$route];
+    }
+
+    /**
+     * @dataProvider routeTypes
+     * @param null|false|Route $route
+     */
+    public function testMiddlewareWillInjectRoutePulledFromRequestRouteResult($route)
+    {
+        $routeResult = $this->prophesize(RouteResult::class);
+        $routeResult
+            ->getMatchedRoute()
+            ->willReturn($route)
+            ->shouldBeCalledTimes(1);
+
+        $this->request
+            ->getAttribute(TemplateVariableContainer::class)
+            ->willReturn($this->container)
+            ->shouldBeCalledTimes(1);
+
+        $this->request
+            ->getAttribute(RouteResult::class, null)
+            ->will([$routeResult, 'reveal'])
+            ->shouldBeCalledTimes(1);
+
+        $this->handler
+            ->handle(Argument::that([$this->request, 'reveal']))
+            ->will([$this->response, 'reveal']);
+
+        $this->assertSame(
+            $this->response->reveal(),
+            $this->middleware->process($this->request->reveal(), $this->handler->reveal())
+        );
+
+        $this->assertTrue($this->container->has('route'));
+        $this->assertSame($route, $this->container->get('route'));
+    }
+}

--- a/test/Template/RouteTemplateVariableMiddlewareTest.php
+++ b/test/Template/RouteTemplateVariableMiddlewareTest.php
@@ -64,6 +64,20 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
             ->willReturn(null)
             ->shouldBeCalledTimes(1);
 
+        $originalContainer = $this->container;
+        $this->request
+            ->withAttribute(
+                TemplateVariableContainer::class,
+                Argument::that(function ($container) use ($originalContainer) {
+                    TestCase::assertNotSame($container, $originalContainer);
+                    TestCase::assertTrue($container->has('route'));
+                    TestCase::assertNull($container->get('route'));
+                    return $container;
+                })
+            )
+            ->will([$this->request, 'reveal'])
+            ->shouldBeCalledTimes(1);
+
         $this->handler
             ->handle(Argument::that([$this->request, 'reveal']))
             ->will([$this->response, 'reveal']);
@@ -72,9 +86,6 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
             $this->response->reveal(),
             $this->middleware->process($this->request->reveal(), $this->handler->reveal())
         );
-
-        $this->assertTrue($this->container->has('route'));
-        $this->assertNull($this->container->get('route'));
     }
 
     public function routeTypes() : iterable
@@ -108,6 +119,20 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
             ->will([$routeResult, 'reveal'])
             ->shouldBeCalledTimes(1);
 
+        $originalContainer = $this->container;
+        $this->request
+            ->withAttribute(
+                TemplateVariableContainer::class,
+                Argument::that(function ($container) use ($originalContainer, $route) {
+                    TestCase::assertNotSame($container, $originalContainer);
+                    TestCase::assertTrue($container->has('route'));
+                    TestCase::assertSame($container->get('route'), $route);
+                    return $container;
+                })
+            )
+            ->will([$this->request, 'reveal'])
+            ->shouldBeCalledTimes(1);
+
         $this->handler
             ->handle(Argument::that([$this->request, 'reveal']))
             ->will([$this->response, 'reveal']);
@@ -116,8 +141,5 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
             $this->response->reveal(),
             $this->middleware->process($this->request->reveal(), $this->handler->reveal())
         );
-
-        $this->assertTrue($this->container->has('route'));
-        $this->assertSame($route, $this->container->get('route'));
     }
 }

--- a/test/Template/TemplateVariableContainerMiddlewareTest.php
+++ b/test/Template/TemplateVariableContainerMiddlewareTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Helper\Template;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Helper\Template\TemplateVariableContainer;
+use Zend\Expressive\Helper\Template\TemplateVariableContainerMiddleware;
+
+class TemplateVariableContainerMiddlewareTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->handler    = $this->prophesize(RequestHandlerInterface::class);
+        $this->request    = $this->prophesize(ServerRequestInterface::class);
+        $this->response   = $this->prophesize(ResponseInterface::class)->reveal();
+        $this->middleware = new TemplateVariableContainerMiddleware();
+    }
+
+    public function testProcessInjectsVariableContainerIntoRequestPassedToHandler()
+    {
+        $this->request
+            ->getAttribute(TemplateVariableContainer::class)
+            ->willReturn(null)
+            ->shouldBeCalledTimes(1);
+
+        $clonedRequest = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $this->request
+            ->withAttribute(TemplateVariableContainer::class, Argument::type(TemplateVariableContainer::class))
+            ->willReturn($clonedRequest)
+            ->shouldBeCalledTimes(1);
+
+        $this->handler
+            ->handle($clonedRequest)
+            ->willReturn($this->response)
+            ->shouldBeCalledTimes(1);
+
+        $this->assertSame(
+            $this->response,
+            $this->middleware->process(
+                $this->request->reveal(),
+                $this->handler->reveal()
+            )
+        );
+    }
+
+    public function testProcessIsANoOpIfVariableContainerIsAlreadyInRequest()
+    {
+        $container = new TemplateVariableContainer();
+
+        $this->request
+            ->getAttribute(TemplateVariableContainer::class)
+            ->willReturn($container)
+            ->shouldBeCalledTimes(1);
+
+        $this->request
+            ->withAttribute(TemplateVariableContainer::class, $container)
+            ->shouldNotBeCalled();
+
+        $this->handler
+            ->handle(Argument::that([$this->request, 'reveal']))
+            ->willReturn($this->response)
+            ->shouldBeCalledTimes(1);
+
+        $this->assertSame(
+            $this->response,
+            $this->middleware->process(
+                $this->request->reveal(),
+                $this->handler->reveal()
+            )
+        );
+    }
+}

--- a/test/Template/TemplateVariableContainerTest.php
+++ b/test/Template/TemplateVariableContainerTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-helpers for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-helpers/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Helper\Template;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Helper\Template\TemplateVariableContainer;
+
+class TemplateVariableContainerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = new TemplateVariableContainer();
+    }
+
+    public function testContainerIsEmptyByDefault()
+    {
+        $this->assertCount(0, $this->container);
+    }
+
+    public function testCanSetVariables() : TemplateVariableContainer
+    {
+        $this->container->set('key', 'value');
+        $this->assertCount(1, $this->container);
+        $this->assertTrue($this->container->has('key'));
+        $this->assertSame('value', $this->container->get('key'));
+        return $this->container;
+    }
+
+    public function testHasReturnsFalseForUnsetVariables()
+    {
+        $this->assertFalse($this->container->has('key'));
+    }
+
+    public function testGetReturnsNullForUnsetVariables()
+    {
+        $this->assertNull($this->container->get('key'));
+    }
+
+    /**
+     * @depends testCanSetVariables
+     */
+    public function testCanUnsetVariableFromContainer(TemplateVariableContainer $container)
+    {
+        $container->unset('key');
+        $this->assertFalse($container->has('key'));
+    }
+
+    public function testCanMergeArrayIntoContainer()
+    {
+        $values = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ];
+
+        $this->container->merge($values);
+
+        foreach ($values as $key => $value) {
+            $this->assertTrue($this->container->has($key));
+            $this->assertEquals($value, $this->container->get($key));
+        }
+    }
+
+    public function testWillReturnArrayWhenRequestedToMergeForTemplate()
+    {
+        $containerValues = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ];
+
+        $localValues = [
+            'foo'  => 'FOO',
+            'else' => 'something',
+        ];
+
+        $expected = array_merge($containerValues, $localValues);
+
+        $this->container->merge($containerValues);
+
+        $merged = $this->container->mergeForTemplate($localValues);
+
+        $this->assertSame($expected, $merged);
+    }
+}

--- a/test/Template/TemplateVariableContainerTest.php
+++ b/test/Template/TemplateVariableContainerTest.php
@@ -24,13 +24,16 @@ class TemplateVariableContainerTest extends TestCase
         $this->assertCount(0, $this->container);
     }
 
-    public function testCanSetVariables() : TemplateVariableContainer
+    public function testSettingVariablesReturnsNewInstanceContainingValue() : TemplateVariableContainer
     {
-        $this->container->set('key', 'value');
-        $this->assertCount(1, $this->container);
-        $this->assertTrue($this->container->has('key'));
-        $this->assertSame('value', $this->container->get('key'));
-        return $this->container;
+        $container = $this->container->with('key', 'value');
+
+        $this->assertNotSame($container, $this->container);
+        $this->assertCount(1, $container);
+        $this->assertTrue($container->has('key'));
+        $this->assertSame('value', $container->get('key'));
+
+        return $container;
     }
 
     public function testHasReturnsFalseForUnsetVariables()
@@ -44,15 +47,18 @@ class TemplateVariableContainerTest extends TestCase
     }
 
     /**
-     * @depends testCanSetVariables
+     * @depends testSettingVariablesReturnsNewInstanceContainingValue
      */
-    public function testCanUnsetVariableFromContainer(TemplateVariableContainer $container)
+    public function testCallingWithoutReturnsNewInstanceWithoutValue(TemplateVariableContainer $original)
     {
-        $container->unset('key');
+        $container = $original->without('key');
+
+        $this->assertNotSame($container, $original);
+        $this->assertTrue($original->has('key'));
         $this->assertFalse($container->has('key'));
     }
 
-    public function testCanMergeArrayIntoContainer()
+    public function testMergeReturnsNewInstanceContainingMergedArray()
     {
         $values = [
             'foo' => 'bar',
@@ -60,11 +66,15 @@ class TemplateVariableContainerTest extends TestCase
             'baz' => 'bat',
         ];
 
-        $this->container->merge($values);
+        $container = $this->container->merge($values);
+
+        $this->assertNotSame($container, $this->container);
 
         foreach ($values as $key => $value) {
-            $this->assertTrue($this->container->has($key));
-            $this->assertEquals($value, $this->container->get($key));
+            $this->assertFalse($this->container->has($key));
+            $this->assertTrue($container->has($key));
+            $this->assertNull($this->container->get($key));
+            $this->assertEquals($value, $container->get($key));
         }
     }
 
@@ -83,9 +93,9 @@ class TemplateVariableContainerTest extends TestCase
 
         $expected = array_merge($containerValues, $localValues);
 
-        $this->container->merge($containerValues);
+        $container = $this->container->merge($containerValues);
 
-        $merged = $this->container->mergeForTemplate($localValues);
+        $merged = $container->mergeForTemplate($localValues);
 
         $this->assertSame($expected, $merged);
     }


### PR DESCRIPTION
`TemplateRendererInterface::addDefaultParam()` has side-effects, and should not be used in async environments unless setting template variables that will be used on **every** request.

As such, this patch introduces an alternative workflow for aggregating pipeline-specific template variables. It provides two classes:

- `Zend\Expressive\Helper\Template\TemplateVariableContainer`, which provides a way to aggregate template variables, as well as merge local variables for the purpose of producing a set to pass to the template renderer.
- `Zend\Expressive\Helper\Template\TemplateVariableContainerMiddleware`, which provides a way to register the container as a request attribute within your pipeline.

Middleware can then set template parameters using either the container's `set()` or `merge()` methods:

```php
$request->getAttribute(TemplateVariableContainer::class)
   ->set('user', $user);

$request->getAttribute(TemplateVariableContainer::class)
   ->merge([
       'user'  => $user,
       'route' => $route,
   );
```

Handlers can then use the `mergeForTemplate()` method to prepare variables to pass to the renderer:

```php
$content = $this->renderer->render(
   'some::template',
   $container->mergeForTemplate([
       'handler-specific-variable' => $value,
   ])
);
```

Additionally, this patch provides `Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware`. This middleware works in conjunction with the `TemplateVariableContainerMiddleware`, and inspects the request for a `Zend\Expressive\Router\RouteResult` instance. If found, it injects the value returned by `getMatchedRoute()` under the name `route` in the `TemplateVariableContainer`, allowing templates access to it via the variable `$route`. This value will either be empty, or a `Zend\Expressive\Router\Route` instance.

The `RouteTemplateVariableMiddleware` can be used in place of the `UrlHelperMiddleware`, particularly if you do not use the `UrlHelper` without a route name.