### PR TITLE
WIP: changed UrlHelper::getRouteResult in public for usage as view helper

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -147,10 +147,7 @@ class UrlHelper
         $this->basePath = '/' . ltrim($path, '/');
     }
 
-    /**
-     * Internal accessor for retrieving the route result.
-     */
-    protected function getRouteResult() : ?RouteResult
+    public function getRouteResult() : ?RouteResult
     {
         return $this->result;
     }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -377,4 +377,19 @@ class UrlHelperTest extends TestCase
             )
         );
     }
+
+    public function testGetRouteResultIfNoRouteResultSet()
+    {
+        $helper = $this->createHelper();
+        $this->assertNull($helper->getRouteResult());
+    }
+
+    public function testGetRouteResultWithRouteResultSet()
+    {
+        $helper = $this->createHelper();
+        $result = $this->prophesize(RouteResult::class);
+
+        $helper->setRouteResult($result->reveal());
+        $this->assertInstanceOf(RouteResult::class, $helper->getRouteResult());
+    }
 }


### PR DESCRIPTION
I would like to offer a `RouteResult` object as a view helper, in order to get the matched route name and params. The usage of getRouteResult as public method simplify the implementation of such view helper.